### PR TITLE
Add time-series helpers and diagnostics update

### DIFF
--- a/src/innovate/plots/diagnostics.py
+++ b/src/innovate/plots/diagnostics.py
@@ -9,7 +9,8 @@ def plot_residuals(
     t: np.ndarray,
     y: np.ndarray,
     title: str = "Residual Analysis",
-    lags: int = 30
+    lags: int = 30,
+    acf_only: bool = False,
 ):
     """
     Plots the residuals of a fitted model, along with their ACF and PACF plots.
@@ -35,7 +36,8 @@ def plot_residuals(
     residuals = y - predictions
 
     # Create figure
-    fig, axes = plt.subplots(3, 1, figsize=(10, 12))
+    n_rows = 2 if acf_only else 3
+    fig, axes = plt.subplots(n_rows, 1, figsize=(10, 4 * n_rows))
     fig.suptitle(title, fontsize=16)
 
     # Plot residuals
@@ -49,9 +51,10 @@ def plot_residuals(
     plot_acf(residuals, ax=axes[1], lags=lags)
     axes[1].set_title("Autocorrelation Function (ACF)")
 
-    # Plot PACF
-    plot_pacf(residuals, ax=axes[2], lags=lags)
-    axes[2].set_title("Partial Autocorrelation Function (PACF)")
+    if not acf_only:
+        # Plot PACF
+        plot_pacf(residuals, ax=axes[2], lags=lags)
+        axes[2].set_title("Partial Autocorrelation Function (PACF)")
 
     plt.tight_layout(rect=[0, 0, 1, 0.96])
     plt.show()

--- a/src/innovate/preprocess/__init__.py
+++ b/src/innovate/preprocess/__init__.py
@@ -1,1 +1,2 @@
 from .decomposition import stl_decomposition
+from .time_series import rolling_average, sarima_fit

--- a/src/innovate/preprocess/time_series.py
+++ b/src/innovate/preprocess/time_series.py
@@ -1,0 +1,25 @@
+# src/innovate/preprocess/time_series.py
+
+"""Convenience wrappers around utilities for common time-series preprocessing."""
+
+from __future__ import annotations
+
+import pandas as pd
+from typing import Tuple
+
+from innovate.utils.preprocessing import apply_rolling_average, apply_sarima
+
+
+def rolling_average(series: pd.Series, window: int) -> pd.Series:
+    """Apply a rolling average to ``series`` using ``window`` size."""
+    return apply_rolling_average(series, window)
+
+
+def sarima_fit(
+    series: pd.Series,
+    order: Tuple[int, int, int],
+    seasonal_order: Tuple[int, int, int, int],
+) -> pd.Series:
+    """Fit a SARIMA model and return the fitted values."""
+    return apply_sarima(series, order=order, seasonal_order=seasonal_order)
+

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -31,3 +31,25 @@ def test_stl_decomposition_no_datetime_index():
     series = pd.Series(np.random.rand(100))
     with pytest.raises(TypeError, match="The input series must have a DatetimeIndex."):
         stl_decomposition(series, period=12)
+
+from innovate.preprocess import rolling_average, sarima_fit
+
+@pytest.fixture
+def simple_series():
+    dates = pd.date_range(start='2020-01-01', periods=50, freq='M')
+    return pd.Series(np.arange(50), index=dates)
+
+
+def test_rolling_average(simple_series):
+    ra = rolling_average(simple_series, window=5)
+    assert len(ra) == len(simple_series)
+    # first window-1 values should be NaN
+    assert ra.isna().sum() == 4
+
+
+def test_sarima_fit(simple_series):
+    order = (1, 1, 0)
+    seasonal_order = (0, 0, 0, 0)
+    fitted = sarima_fit(simple_series, order=order, seasonal_order=seasonal_order)
+    assert len(fitted) == len(simple_series)
+


### PR DESCRIPTION
## Summary
- add convenience wrappers `rolling_average` and `sarima_fit` to `preprocess`
- expose new helpers in `preprocess.__init__`
- allow `plot_residuals` to optionally skip the PACF plot
- test the preprocess helpers

## Testing
- `pytest tests/test_preprocess.py tests/test_preprocessing.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68870569bf188331bd7e58b0a6499163