### PR TITLE
Expose AIC/BIC helpers

### DIFF
--- a/src/innovate/backend.py
+++ b/src/innovate/backend.py
@@ -1,11 +1,16 @@
 from innovate.backends.numpy_backend import NumPyBackend
-from innovate.backends.jax_backend import JaxBackend
+try:
+    from innovate.backends.jax_backend import JaxBackend
+except Exception:  # pragma: no cover - optional dependency may be missing
+    JaxBackend = None
 
 current_backend = NumPyBackend()
 
 def use_backend(backend: str):
     global current_backend
     if backend == "jax":
+        if JaxBackend is None:
+            raise ImportError("JAX backend is not available")
         current_backend = JaxBackend()
     elif backend == "numpy":
         current_backend = NumPyBackend()

--- a/src/innovate/models/mixture.py
+++ b/src/innovate/models/mixture.py
@@ -1,0 +1,57 @@
+from typing import Sequence, List, Dict
+import numpy as np
+from innovate.base.base import DiffusionModel
+from innovate.utils.metrics import calculate_r_squared
+
+class MixtureModel(DiffusionModel):
+    def __init__(self, models: List[DiffusionModel], weights: Sequence[float]):
+        self.models = models
+        self.weights = weights
+        self._params: Dict[str, float] = {}
+
+    @property
+    def param_names(self) -> Sequence[str]:
+        names = []
+        for idx, model in enumerate(self.models):
+            for pname in model.param_names:
+                names.append(f"model_{idx}_{pname}")
+        return names
+
+    def initial_guesses(self, t: Sequence[float], y: Sequence[float]) -> Dict[str, float]:
+        guesses = {}
+        for idx, model in enumerate(self.models):
+            for name, val in model.initial_guesses(t, y).items():
+                guesses[f"model_{idx}_{name}"] = val
+        return guesses
+
+    def bounds(self, t: Sequence[float], y: Sequence[float]) -> Dict[str, tuple]:
+        bounds = {}
+        for idx, model in enumerate(self.models):
+            for name, bnd in model.bounds(t, y).items():
+                bounds[f"model_{idx}_{name}"] = bnd
+        return bounds
+
+    def predict(self, t: Sequence[float], covariates: Dict[str, Sequence[float]] = None) -> Sequence[float]:
+        preds = np.zeros_like(t, dtype=float)
+        for w, m in zip(self.weights, self.models):
+            preds += w * m.predict(t)
+        return preds
+
+    def score(self, t: Sequence[float], y: Sequence[float], covariates: Dict[str, Sequence[float]] = None) -> float:
+        y_pred = self.predict(t, covariates)
+        return calculate_r_squared(y, y_pred)
+
+    @property
+    def params_(self) -> Dict[str, float]:
+        return self._params
+
+    @params_.setter
+    def params_(self, value: Dict[str, float]):
+        self._params = value
+
+    def predict_adoption_rate(self, t: Sequence[float], covariates: Dict[str, Sequence[float]] = None) -> Sequence[float]:
+        raise NotImplementedError
+
+    @staticmethod
+    def differential_equation(y, t, p):
+        raise NotImplementedError

--- a/src/innovate/utils/__init__.py
+++ b/src/innovate/utils/__init__.py
@@ -13,6 +13,8 @@ from .metrics import (
 from .model_evaluation import (
     compare_models,
     find_best_model,
+    model_aic,
+    model_bic,
 )
 
 from .preprocessing import (

--- a/src/innovate/utils/model_evaluation.py
+++ b/src/innovate/utils/model_evaluation.py
@@ -3,16 +3,38 @@ import numpy as np
 from typing import Dict, Any, List, Sequence, Tuple
 from innovate.base.base import DiffusionModel
 from .metrics import (
-    calculate_mse, 
-    calculate_rmse, 
-    calculate_mae, 
-    calculate_r_squared, 
-    calculate_mape, 
+    calculate_mse,
+    calculate_rmse,
+    calculate_mae,
+    calculate_r_squared,
+    calculate_mape,
     calculate_smape,
     calculate_rss,
     calculate_aic,
     calculate_bic
 )
+
+
+def model_aic(model: DiffusionModel, t: Sequence[float], y: Sequence[float]) -> float:
+    """Return the Akaike Information Criterion for a fitted model."""
+    if not model.params_:
+        raise RuntimeError("Model has not been fitted yet. Call .fit() first.")
+    y_pred = model.predict(t)
+    rss = calculate_rss(y, y_pred)
+    n_samples = len(y)
+    n_params = len(model.param_names) + 1
+    return calculate_aic(n_params, n_samples, rss)
+
+
+def model_bic(model: DiffusionModel, t: Sequence[float], y: Sequence[float]) -> float:
+    """Return the Bayesian Information Criterion for a fitted model."""
+    if not model.params_:
+        raise RuntimeError("Model has not been fitted yet. Call .fit() first.")
+    y_pred = model.predict(t)
+    rss = calculate_rss(y, y_pred)
+    n_samples = len(y)
+    n_params = len(model.param_names) + 1
+    return calculate_bic(n_params, n_samples, rss)
 
 def get_fit_metrics(model: DiffusionModel, t: Sequence[float], y: Sequence[float]) -> Dict[str, float]:
     """

--- a/tests/test_model_evaluation.py
+++ b/tests/test_model_evaluation.py
@@ -1,0 +1,26 @@
+import numpy as np
+from innovate.diffuse.bass import BassModel
+from innovate.utils.model_evaluation import model_aic, model_bic
+from innovate.utils.metrics import calculate_rss, calculate_aic, calculate_bic
+
+
+def test_model_aic_bic():
+    t = np.arange(0, 10)
+    true_model = BassModel()
+    true_model.params_ = {"p": 0.02, "q": 0.3, "m": 1000}
+    y_true = true_model.predict(t)
+
+    fitted_model = BassModel()
+    fitted_model.params_ = {"p": 0.03, "q": 0.25, "m": 900}
+
+    aic_value = model_aic(fitted_model, t, y_true)
+    bic_value = model_bic(fitted_model, t, y_true)
+
+    rss = calculate_rss(y_true, fitted_model.predict(t))
+    n_samples = len(y_true)
+    n_params = len(fitted_model.param_names) + 1
+    expected_aic = calculate_aic(n_params, n_samples, rss)
+    expected_bic = calculate_bic(n_params, n_samples, rss)
+
+    assert np.isclose(aic_value, expected_aic)
+    assert np.isclose(bic_value, expected_bic)


### PR DESCRIPTION
## Summary
- add `model_aic` and `model_bic` helpers that wrap metric calculations
- re-export new helpers from `utils.__init__`
- provide a fallback for missing JAX backend
- add simple `MixtureModel` stub for tests
- test model AIC/BIC computation

## Testing
- `pytest tests/test_model_evaluation.py -q`
- `pytest -q` *(fails: Can't instantiate abstract class LogisticModel, missing sympy, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68870572ba0883319e5d2bdc9f9be432