### PR TITLE
Add coverage reporting to CI

### DIFF
--- a/.github/workflows/python_ci.yml
+++ b/.github/workflows/python_ci.yml
@@ -16,10 +16,20 @@ jobs:
         python -m pip install --upgrade pip
         pip install poetry
         poetry install --with dev
-    - name: Run tests
-      run: poetry run pytest
+        pip install coverage
+    - name: Run tests with coverage
+      run: |
+        poetry run coverage run -m pytest
+        poetry run coverage xml
       env:
         PYTHONPATH: src
+    - name: Check coverage threshold
+      run: poetry run coverage report --fail-under=90
+    - name: Upload coverage report
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverage-report
+        path: coverage.xml
     - name: Run ruff
       run: poetry run ruff check .
     - name: Run black


### PR DESCRIPTION
## Summary
- run pytest with coverage in GitHub Actions
- check that coverage is at least 90%
- upload coverage.xml as an artifact

## Testing
- `coverage run -m pytest` *(fails: 17 errors during collection)*
- `coverage report --fail-under=90` *(fails: total of 14 is less than fail-under=90)*
- `ruff check .` *(fails: 577 errors)*
- `black --check .` *(fails: would reformat 101 files)*

------
https://chatgpt.com/codex/tasks/task_e_68873452017c833188d13586b4f95ecc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced automated testing to enforce a minimum code coverage of 90%.
  * Test coverage reports are now generated and made available for download after each run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->