### PR TITLE
Add testing strategy documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,11 @@ We are continuing to investigate opportunities for optimization, including the u
 ## License
 
 This project is licensed under the Apache 2.0 License.
+
+## Testing
+
+See the [Testing Strategy](docs/testing_strategy.rst) document for details on
+how to run the test suite and how different tests are categorized.
 ## Branching Strategy
 
 This repository now uses `main` as the primary development branch. Existing branches can be rebased or merged onto `main`.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -38,3 +38,9 @@ Welcome to the documentation for the ``innovate`` library.
    innovate.fitters.rst
    innovate.base.rst
 
+.. toctree::
+   :maxdepth: 1
+   :caption: Development
+
+   ../testing_strategy
+

--- a/docs/testing_strategy.rst
+++ b/docs/testing_strategy.rst
@@ -1,0 +1,40 @@
+Testing Strategy
+===============
+
+This project uses **pytest** for all automated tests. We group tests into
+three broad categories:
+
+Unit tests
+  Cover the smallest pieces of functionality in isolation. These tests
+  should not touch the filesystem or network and should execute very
+  quickly.
+
+Integration tests
+  Exercise the interaction of several components together. They may read
+  from small data files or require more complex setup but still run
+  entirely within the Python process.
+
+End-to-end (E2E) tests
+  Run through the library as a user would, potentially calling command
+  line interfaces or full workflows. These tests tend to be slower and
+  may rely on example datasets.
+
+Running tests with coverage
+---------------------------
+
+The recommended command to run the full suite with coverage enabled is::
+
+    pytest --cov=innovate --cov-report=term-missing
+
+This reports line coverage for the ``innovate`` package and highlights any
+missing lines in the output.
+
+Marking tests
+-------------
+
+Please mark tests according to their scope using ``pytest`` markers. Use
+``@pytest.mark.unit`` for unit tests, ``@pytest.mark.integration`` for
+integration tests and ``@pytest.mark.e2e`` for end-to-end tests. Markers
+allow selective running, for example ``pytest -m unit`` runs only unit
+tests.
+

--- a/src/innovate/backend.py
+++ b/src/innovate/backend.py
@@ -2,8 +2,6 @@ from innovate.backends.numpy_backend import NumPyBackend
 
 try:
     from innovate.backends.jax_backend import JaxBackend  # type: ignore
-try:
-    from innovate.backends.jax_backend import JaxBackend
 except Exception:  # pragma: no cover - optional dependency may be missing
     JaxBackend = None
 


### PR DESCRIPTION
## Summary
- document the testing strategy
- link testing docs from README and Sphinx index
- fix broken try/except in backend

## Testing
- `pytest -q`
- `pytest --cov=innovate --cov-report=term-missing -q`

------
https://chatgpt.com/codex/tasks/task_e_68873451a874833190163b9883caa7d0