### PR TITLE
Update coverage handling in CI

### DIFF
--- a/.github/workflows/python_ci.yml
+++ b/.github/workflows/python_ci.yml
@@ -19,12 +19,12 @@ jobs:
         pip install coverage
     - name: Run tests with coverage
       run: |
-        poetry run coverage run -m pytest
-        poetry run coverage xml
+        coverage run -m pytest
+        coverage xml
       env:
         PYTHONPATH: src
     - name: Check coverage threshold
-      run: poetry run coverage report --fail-under=90
+      run: coverage report --fail-under=90
     - name: Upload coverage report
       uses: actions/upload-artifact@v4
       with:


### PR DESCRIPTION
## Summary
- run `coverage run -m pytest` in CI
- enforce a 90% coverage threshold
- upload `coverage.xml` as a workflow artifact

## Testing
- `coverage run -m pytest`
- `coverage xml`
- `coverage report --fail-under=90` *(fails: total of 75 is less than fail-under=90)*

------
https://chatgpt.com/codex/tasks/task_e_6887429c0f5c8331a263198e564eda91

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Python CI workflow to simplify coverage command execution in the GitHub Actions pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->