### PR TITLE
Fix BayesianFitter boolean crash

### DIFF
--- a/src/innovate/diffuse/bass.py
+++ b/src/innovate/diffuse/bass.py
@@ -139,7 +139,7 @@ class BassModel(DiffusionModel):
                 param_idx += 3
 
         rate = (p_t + q_t * (y / m_t)) * (m_t - y)
-        return rate if m_t > 0 else 0.0
+        return pt.switch(m_t > 0, rate, 0.0)
 
     def score(self, t: Sequence[float], y: Sequence[float], covariates: Dict[str, Sequence[float]] = None) -> float:
         """

--- a/tests/test_bayesian_fitter.py
+++ b/tests/test_bayesian_fitter.py
@@ -7,6 +7,7 @@ from innovate.fitters.bayesian_fitter import BayesianFitter
 
 @pytest.fixture
 def synthetic_bass_data():
+    np.random.seed(0)
     t = np.linspace(0, 20, 100)
     p, q, m = 0.03, 0.38, 1.0
     y = m * (1 - np.exp(-(p + q) * t)) / (1 + (q / p) * np.exp(-(p + q) * t))
@@ -16,7 +17,7 @@ def synthetic_bass_data():
 def test_bayesian_fitter(synthetic_bass_data):
     t, y = synthetic_bass_data
     model = BassModel()
-    fitter = BayesianFitter(model, draws=10, tune=10, chains=1, cores=1)
+    fitter = BayesianFitter(model, draws=20, tune=20, chains=1, cores=1)
     fitter.fit(t, y)
 
     assert model.params_ is not None


### PR DESCRIPTION
## Summary
- avoid symbolic boolean in BassModel by using `pt.switch`
- adjust BayesianFitter test to use reproducible data and 20-draw single-chain sampling

## Testing
- `pytest tests/test_bayesian_fitter.py::test_bayesian_fitter -q`

------
https://chatgpt.com/codex/tasks/task_e_6887429b67c08331a751389c71c94be8