### PR TITLE
Fix backend import logic

### DIFF
--- a/src/innovate/backend.py
+++ b/src/innovate/backend.py
@@ -2,10 +2,10 @@
 
 from innovate.backends.numpy_backend import NumPyBackend
 
+# JAX and diffrax are optional dependencies
 try:
-    # JAX and diffrax are optional dependencies
     from innovate.backends.jax_backend import JaxBackend  # type: ignore
-except Exception:  # pragma: no cover - optional dependency may be missing
+except ImportError:  # pragma: no cover - optional dependency may be missing
     JaxBackend = None
 
 current_backend = NumPyBackend()
@@ -23,8 +23,6 @@ def use_backend(backend: str):
         current_backend = NumPyBackend()
     else:
         raise ValueError(f"Unknown backend: {backend}")
-
-
 
 # Initialize with the NumPy backend by default
 use_backend("numpy")


### PR DESCRIPTION
## Summary
- simplify jax backend import

## Testing
- `pytest --maxfail=1 -q` *(fails: TracerArrayConversionError from jax in `test_batched_fitter_jax`)*

------
https://chatgpt.com/codex/tasks/task_e_6887489d7ff88331a5205c488142bc4e