### PR TITLE
Fix BayesianFitter test config

### DIFF
--- a/tests/test_bayesian_fitter.py
+++ b/tests/test_bayesian_fitter.py
@@ -18,7 +18,7 @@ def test_bayesian_fitter(synthetic_bass_data):
     t, y = synthetic_bass_data
     model = BassModel()
     fitter = BayesianFitter(model, draws=20, tune=20, chains=1, cores=1)
-    fitter.fit(t, y)
+    fitter.fit(t, y, target_accept=0.9)
 
     assert model.params_ is not None
     assert len(model.params_) == 3  # p, q, m


### PR DESCRIPTION
## Summary
- adjust BayesianFitter test to use a higher `target_accept` value

## Testing
- `pytest tests/test_bayesian_fitter.py::test_bayesian_fitter -vv`

------
https://chatgpt.com/codex/tasks/task_e_6887489de52c8331b24a72b849d894db