### PR TITLE
Fix JAX fitter errors and update models

### DIFF
--- a/src/innovate/abm/ndlib_model.py
+++ b/src/innovate/abm/ndlib_model.py
@@ -22,6 +22,7 @@ class NDlibModel(Model):
         Raises:
             ValueError: If an unsupported model_name is provided.
         """
+        super().__init__()
         self.num_agents = num_agents
         self.running = True
 

--- a/src/innovate/backends/jax_backend.py
+++ b/src/innovate/backends/jax_backend.py
@@ -7,11 +7,20 @@ class JaxBackend:
     def array(self, data):
         return jnp.asarray(data)
 
-    exp = jnp.exp
-    power = jnp.power
-    sum = jnp.sum
-    mean = jnp.mean
-    where = jnp.where
+    def exp(self, x):
+        return jnp.exp(x)
+
+    def power(self, x, y):
+        return jnp.power(x, y)
+
+    def sum(self, a, axis=None, dtype=None, keepdims=False):
+        return jnp.sum(a, axis=axis, dtype=dtype, keepdims=keepdims)
+
+    def mean(self, a, axis=None, dtype=None, keepdims=False):
+        return jnp.mean(a, axis=axis, dtype=dtype, keepdims=keepdims)
+
+    def where(self, condition, x, y):
+        return jnp.where(condition, x, y)
 
     def log(self, x):
         return jnp.log(x)
@@ -37,6 +46,9 @@ class JaxBackend:
 
     def median(self, x: jnp.ndarray) -> float:
         return jnp.median(x)
+
+    def interp(self, x, xp, fp):
+        return jnp.interp(x, xp, fp)
 
     def jit(self, f: Callable) -> Callable:
         return jax.jit(f)

--- a/src/innovate/backends/numpy_backend.py
+++ b/src/innovate/backends/numpy_backend.py
@@ -46,6 +46,9 @@ class NumPyBackend:
     def median(self, x: np.ndarray) -> float:
         return np.median(x)
 
+    def interp(self, x, xp, fp):
+        return np.interp(x, xp, fp)
+
     def jit(self, f):
         return f
 

--- a/src/innovate/path_dependence/lock_in.py
+++ b/src/innovate/path_dependence/lock_in.py
@@ -70,8 +70,16 @@ class LockInModel(DiffusionModel):
         if not self._params:
             raise RuntimeError("Model parameters have not been set.")
 
-        sol = odeint(self.differential_equation, y0, t, args=tuple(self._params.values()))
-        return np.maximum(0, sol) # Ensure non-negative predictions
+        sol = odeint(
+            self.differential_equation,
+            y0,
+            t,
+            args=tuple(self._params.values()),
+        )
+        sol = np.maximum(0, sol)
+        m = self._params.get("m", np.inf)
+        sol = np.minimum(sol, m)
+        return sol
 
     def fit(self, t: Sequence[float], y: np.ndarray, **kwargs):
         from scipy.optimize import minimize

--- a/src/innovate/policy/intervention.py
+++ b/src/innovate/policy/intervention.py
@@ -56,12 +56,12 @@ class PolicyIntervention:
         def predict_with_policy(t_eval: Sequence[float]) -> Sequence[float]:
             predictions = []
             for t_val in t_eval:
-                # Find the closest policy parameters for t_val
-                # This is a very basic interpolation/selection
                 idx = np.argmin(np.abs(np.array(t_points) - t_val))
-                temp_model = self.model.__class__() # Create a new instance of the same model type
-                temp_model.params_ = modified_params_at_t_points[idx]
-                predictions.append(temp_model.predict([t_val])[0]) # Predict for single time point
+                params = modified_params_at_t_points[idx]
+                p, q, m = params["p"], params["q"], params["m"]
+                expo = np.exp(-(p + q) * t_val)
+                pred = m * (1 - expo) / (1 + (q / p) * expo)
+                predictions.append(pred)
             return np.array(predictions)
 
         return predict_with_policy


### PR DESCRIPTION
## Summary
- add `interp` to backends and make JAX backend callable
- update logistic and bass models to use dynamic backend and support keyword params
- clip LockIn model predictions
- implement analytic Fisher-Pry predict
- improve policy intervention prediction
- initialize NDlibModel parent class

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688755bb58248331be626090351df7ab