### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python_ci.yml
+++ b/.github/workflows/python_ci.yml
@@ -1,4 +1,6 @@
 name: Python CI
+permissions:
+  contents: read
 
 on: [push, pull_request]
 


### PR DESCRIPTION
Potential fix for [https://github.com/edithatogo/innovate/security/code-scanning/1](https://github.com/edithatogo/innovate/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. Since the workflow only checks out code, installs dependencies, runs tests, and uploads an artifact (which does not require write access to repository contents), the minimal permission required is `contents: read`. This block should be added at the top level of the workflow (just after the `name:` line and before `on:`), so it applies to all jobs in the workflow. No changes to the steps or other parts of the workflow are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
