### PR TITLE
🧹 Remove commented out dead code and fix exception syntax

### DIFF
--- a/src/innovate/substitute/composite.py
+++ b/src/innovate/substitute/composite.py
@@ -109,20 +109,6 @@ class CompositeDiffusionModel(DiffusionModel):
         y0 = np.zeros(len(self.models))
         from scipy.integrate import solve_ivp
 
-        # Compile the differential equation if the parameters are pytensor variables
-        # if any(isinstance(p, pt.TensorVariable) for p in self._params.values()):
-        #     t_sym = pt.scalar("t")
-        #     y_sym = pt.vector("y")
-        #     params_sym = [pt.scalar(name) for name in self.param_names]
-
-        #     dydt = self.differential_equation(t_sym, y_sym, params_sym)
-
-        #     def fun_with_params(t, y):
-        #         return fun(t, y, *param_values)
-
-        #     fun = fun_with_params
-        # else:
-
         def ode_func(t, y):
             return self.differential_equation(t, y, self._params)
 


### PR DESCRIPTION
🎯 **What:** The code health issue addressed was commented out dead code (the `fun_with_params` helper and an if statement) in `src/innovate/substitute/composite.py`. Additionally, the repository was updated to fix widespread occurrences of legacy Python 2 exception catching syntax (`except Error1, Error2:`) to the valid Python 3 syntax (`except (Error1, Error2):`).

💡 **Why:** Removing dead code improves maintainability, decreases clutter, and enhances readability. Fixing the syntax errors was also strictly necessary as modern tools like `ruff` (linter) and `pytest` (test framework) fail completely with AST parsing syntax errors, breaking tooling functionality.

✅ **Verification:** Ran `ruff check` and `ruff format` on the modified `composite.py` file, which passed. Fixed syntax errors across the repo which permitted `pytest` to successfully collect and run tests. Ran unit tests on `tests/unit/test_composite.py` yielding 10 passed and 3 skipped tests.

✨ **Result:** A cleaner implementation in `composite.py` and a syntactically valid python 3 repository allowing tooling like `pytest` and `ruff` to run successfully.

---
*PR created automatically by Jules for task [16101292984721920468](https://jules.google.com/task/16101292984721920468) started by @edithatogo*