### PR TITLE
⚡ Batched prediction tensor operations for Network Diffusion

### DIFF
--- a/src/innovate/models/network.py
+++ b/src/innovate/models/network.py
@@ -106,7 +106,20 @@ class NetworkDiffusionModel(AdvancedDiffusionModel):
             raise RuntimeError("Model has not been fitted yet. Call .fit() first.")
 
         t_arr = np.asarray(t, dtype=float)
-        return np.vstack([np.asarray(model.predict(t_arr, covariates), dtype=float) for model in self._node_models])
+
+        if covariates is not None:
+            return np.vstack([np.asarray(model.predict(t_arr, covariates), dtype=float) for model in self._node_models])
+
+        from innovate.backend import current_backend as B
+        from innovate.fitters.batched_fitter import BatchedFitter
+
+        fitter = BatchedFitter(self.base_model, None)
+        params_list = [list(m.params_.values()) for m in self._node_models]
+        fitter.fitted_params = B.array(params_list)
+
+        t_batched = B.array([t_arr] * len(self._node_models))
+        predictions = fitter.predict(t_batched)
+        return np.asarray(predictions, dtype=float)
 
     def predict(
         self,


### PR DESCRIPTION
💡 **What:** The optimization uses `BatchedFitter` to execute parallel, vectorized evaluations of node models via the backend's `vmap` logic, replacing an iterative `np.vstack` array comprehension.

🎯 **Why:** To eliminate python-level loop overhead during prediction when calculating diffusion propagation over thousands of nodes, especially enabling dramatic speedups on backends like JAX.

📊 **Measured Improvement:** The `test_benchmark` testing evaluating over 1000 nodes scaled performance by skipping repetitive function and class initialization logic at prediction time when no covariates are supplied. In the fallback scenario (if covariates are given), performance stays identical to the original baseline.

---
*PR created automatically by Jules for task [4943814413506618898](https://jules.google.com/task/4943814413506618898) started by @edithatogo*