### PR TITLE
🧪 Add tests for normalize_stability_tier

### DIFF
--- a/tests/unit/test_stability.py
+++ b/tests/unit/test_stability.py
@@ -8,6 +8,7 @@ from innovate.stability import (
     STABILITY_LIFECYCLE_RULES,
     StabilityTier,
     describe_stability_tier,
+    normalize_stability_tier,
 )
 
 
@@ -39,3 +40,31 @@ def test_describe_stability_tier_invalid_value() -> None:
 
     with pytest.raises(ValueError, match="Unknown stability tier 'production'"):
         describe_stability_tier("production")
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (StabilityTier.STABLE, StabilityTier.STABLE),
+        (StabilityTier.PROVISIONAL, StabilityTier.PROVISIONAL),
+        (StabilityTier.INTERNAL, StabilityTier.INTERNAL),
+        ("stable", StabilityTier.STABLE),
+        (" STABLE ", StabilityTier.STABLE),
+        ("beta", StabilityTier.PROVISIONAL),
+        ("BETA", StabilityTier.PROVISIONAL),
+        ("experimental", StabilityTier.PROVISIONAL),
+        ("provisional", StabilityTier.PROVISIONAL),
+        ("internal", StabilityTier.INTERNAL),
+        ("internal-only", StabilityTier.INTERNAL),
+        (" InTeRnAl-OnLy ", StabilityTier.INTERNAL),
+    ],
+)
+def test_normalize_stability_tier_success(value: str | StabilityTier, expected: StabilityTier) -> None:
+    """It should correctly normalize valid strings and enums to StabilityTier."""
+    assert normalize_stability_tier(value) is expected
+
+
+def test_normalize_stability_tier_error() -> None:
+    """It should raise ValueError for unknown stability tiers."""
+    with pytest.raises(ValueError, match="Unknown stability tier 'unknown'"):
+        normalize_stability_tier("unknown")


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The `normalize_stability_tier` function lacked explicit test coverage, relying only on partial coverage from plugin API tests. Added a dedicated test suite.

📊 **Coverage:** What scenarios are now tested
- Direct Enum inputs (e.g., `StabilityTier.STABLE`)
- String inputs (e.g., `"stable"`, `"experimental"`, `"internal-only"`)
- Variations in casing and whitespace (e.g., `" STABLE "`, `"BETA"`)
- Error cases where an invalid/unknown tier string is passed

✨ **Result:** The improvement in test coverage
The module `src/innovate/stability.py` now has robust, explicit testing for its core parsing logic, guaranteeing that valid stability inputs are correctly normalized and invalid ones fail gracefully with the expected `ValueError`.

---
*PR created automatically by Jules for task [13009405374167753041](https://jules.google.com/task/13009405374167753041) started by @edithatogo*