### PR TITLE
🧪 Add test for detect_advanced_backends optional backends

### DIFF
--- a/tests/unit/test_advanced_runtime_contracts.py
+++ b/tests/unit/test_advanced_runtime_contracts.py
@@ -157,3 +157,18 @@ def test_detect_advanced_backends_reports_numpy_available() -> None:
 
     assert detected["numpy"] is True
     assert set(detected) == {"numpy", "jax", "rust"}
+
+
+def test_detect_advanced_backends_optional_backends(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Backend detection should correctly report optional backend availability."""
+    # Test when all optional backends are available
+    monkeypatch.setattr("innovate.advanced_runtime.find_spec", lambda _name: True)
+    detected_available = detect_advanced_backends()
+    assert detected_available["jax"] is True
+    assert detected_available["rust"] is True
+
+    # Test when optional backends are unavailable
+    monkeypatch.setattr("innovate.advanced_runtime.find_spec", lambda _name: None)
+    detected_unavailable = detect_advanced_backends()
+    assert detected_unavailable["jax"] is False
+    assert detected_unavailable["rust"] is False


### PR DESCRIPTION
🎯 **What:** Added a missing unit test for the `detect_advanced_backends` function to verify that optional capabilities (like `jax` and `rust`) are correctly detected based on module availability.

📊 **Coverage:** The new test covers scenarios where the optional backends are available (by simulating successful module location) and scenarios where they are unavailable (simulating failures in finding the module). 

✨ **Result:** Improved test coverage for `innovate.advanced_runtime.detect_advanced_backends` ensuring regressions won't break optional backend detection without triggering test failures.

---
*PR created automatically by Jules for task [16181049123252470209](https://jules.google.com/task/16181049123252470209) started by @edithatogo*