### PR TITLE
🧪 [Testing Improvement] Add unit test for get_registered_extensions immutability and behavior

### DIFF
--- a/tests/unit/test_plugin_api_stability.py
+++ b/tests/unit/test_plugin_api_stability.py
@@ -67,3 +67,31 @@ def test_extension_manifest_rejects_unknown_extension_points() -> None:
             stability=StabilityTier.INTERNAL,
             extension_points=("model_registry", "remote_distribution"),
         )
+
+
+def test_get_registered_extensions_immutability(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The returned registry mapping must be immutable."""
+    # Ensure we start with a clean slate for the test by clearing the internal registry
+    import innovate.plugins
+    monkeypatch.setattr(innovate.plugins, "_REGISTERED_EXTENSIONS", {})
+
+    # Ensure there is at least one extension registered to test content check
+    manifest = ExtensionManifest(
+        name="test-immutability-plugin",
+        version="1.0.0",
+        entrypoint="test.plugin:register",
+        stability=StabilityTier.INTERNAL,
+        extension_points=("diagnostics",),
+    )
+
+    register_extension(manifest)
+
+    registry = get_registered_extensions()
+
+    # Check that content is present
+    assert "test-immutability-plugin" in registry
+    assert registry["test-immutability-plugin"].version == "1.0.0"
+
+    # Check immutability
+    with pytest.raises(TypeError):
+        registry["new-plugin"] = None  # type: ignore[index]


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
This PR addresses a missing test for the `get_registered_extensions` function in `src/innovate/plugins.py`. The function is critical for extension retrieval in the module's ecosystem.

📊 **Coverage:** What scenarios are now tested
- Validating that an installed extension correctly exists in the output mapping and yields its correct version value.
- Validating the immutability of the returned mapping by asserting that item assignment properly throws a `TypeError` (proving the proxy wrapper correctness).

✨ **Result:** The improvement in test coverage
Increased confidence and explicit coverage for `get_registered_extensions` functionality without risking test flakes due to isolated monkeypatching setup.

---
*PR created automatically by Jules for task [17605789727181608078](https://jules.google.com/task/17605789727181608078) started by @edithatogo*