### PR TITLE
🧪 Add tests for dataframe_engine_available

### DIFF
--- a/tests/unit/test_dataframe_engine_experiments.py
+++ b/tests/unit/test_dataframe_engine_experiments.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib.util
+from unittest import mock
 
 import pandas as pd
 import pytest
@@ -89,3 +90,28 @@ def test_dataframe_benchmark_fixture_records_attribution_boundaries() -> None:
     assert payload["attribution"]["tabular_execution"] is True
     assert payload["attribution"]["xla_numerical_kernel"] is False
     assert "correctness_hash" in payload["metrics"]
+
+
+def test_dataframe_engine_available_returns_true_for_pandas_engines() -> None:
+    """Pandas variants should always report as available without import checks."""
+    assert dataframe_engine_available("pandas") is True
+    assert dataframe_engine_available("pandas+pyarrow") is True
+    assert dataframe_engine_available("pandas-pyarrow") is True
+    assert dataframe_engine_available("PANDAS") is True
+
+
+def test_dataframe_engine_available_checks_importlib_for_polars() -> None:
+    """Polars availability should depend on whether the module can be found."""
+    with mock.patch("importlib.util.find_spec", return_value=mock.Mock()) as find_spec_mock:
+        assert dataframe_engine_available("polars") is True
+        find_spec_mock.assert_called_once_with("polars")
+
+    with mock.patch("importlib.util.find_spec", return_value=None) as find_spec_mock:
+        assert dataframe_engine_available("polars") is False
+        find_spec_mock.assert_called_once_with("polars")
+
+
+def test_dataframe_engine_available_raises_on_unsupported_engine() -> None:
+    """Unknown engines should raise ValueError instead of returning False."""
+    with pytest.raises(ValueError, match="Unsupported DataFrame engine: duckdb"):
+        dataframe_engine_available("duckdb")


### PR DESCRIPTION
🎯 **What:** Added unit tests for `dataframe_engine_available` in `tests/unit/test_dataframe_engine_experiments.py` to cover the missing testing gap.
📊 **Coverage:** Scenarios for testing pandas engine variants ("pandas", "pandas+pyarrow"), testing `importlib` behavior via mock for polars (installed and uninstalled cases), and ensuring an unsupported engine correctly raises `ValueError`.
✨ **Result:** Improved test coverage for experimental DataFrame engine checks, providing robust validation.

---
*PR created automatically by Jules for task [18255179978349493813](https://jules.google.com/task/18255179978349493813) started by @edithatogo*