### PR TITLE
🧪 Add explicit test for list_kernel_operations

### DIFF
--- a/tests/unit/test_kernel_contract.py
+++ b/tests/unit/test_kernel_contract.py
@@ -283,3 +283,13 @@ def test_kernel_contract_schema_version_compatibility_helper() -> None:
     assert not kernel._is_schema_version_compatible("1.2", "1.0")
     assert not kernel._is_schema_version_compatible("2.0", "1.0")
     assert not kernel._is_schema_version_compatible("1", "1.0")
+
+
+def test_list_kernel_operations() -> None:
+    """list_kernel_operations should return the canonical tuple of kernel operations."""
+    from innovate import kernel
+
+    operations = kernel.list_kernel_operations()
+    assert isinstance(operations, tuple)
+    assert all(isinstance(op, str) for op in operations)
+    assert operations == kernel.KERNEL_OPERATIONS


### PR DESCRIPTION
🎯 **What:** The testing gap for `list_kernel_operations` in `src/innovate/kernel.py` has been addressed by adding a dedicated unit test in `tests/unit/test_kernel_contract.py`.
📊 **Coverage:** The new test ensures that `list_kernel_operations()` returns the canonical list of operations (`kernel.KERNEL_OPERATIONS`) and properly returns a tuple of strings. This provides explicit, isolated test coverage for this function.
✨ **Result:** Improved test coverage and reliability for kernel operational endpoints, ensuring this contract surface does not silently break in the future without failing its explicit test.

---
*PR created automatically by Jules for task [14860943677657161270](https://jules.google.com/task/14860943677657161270) started by @edithatogo*