### PR TITLE
🧪 Add missing unit test for get_advanced_capability happy path

### DIFF
--- a/tests/unit/test_advanced_runtime_contracts.py
+++ b/tests/unit/test_advanced_runtime_contracts.py
@@ -55,6 +55,15 @@ def test_advanced_capability_validation_and_lookup_errors() -> None:
         get_advanced_capability("unknown")
 
 
+def test_get_advanced_capability_returns_correct_capability() -> None:
+    """Lookup should successfully return an existing advanced capability."""
+    capability = get_advanced_capability("policy_scenario")
+    assert capability.key == "policy_scenario"
+    assert capability.family == "policy"
+    assert capability.stability == "stable"
+    assert capability.supported_backends == ("numpy", "jax", "rust")
+
+
 def test_advanced_result_serializes_to_stable_json_payload() -> None:
     """Result objects should round-trip through JSON without losing metadata."""
     result = AdvancedResult(


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
There was a missing unit test for the "happy path" of `get_advanced_capability` in `src/innovate/advanced_runtime.py`, meaning there was no guarantee it successfully retrieves existing capabilities.

📊 **Coverage:** What scenarios are now tested
Added `test_get_advanced_capability_returns_correct_capability` to `tests/unit/test_advanced_runtime_contracts.py` to ensure calling `get_advanced_capability` with a valid key returns the expected `AdvancedCapability` instance with all correct attributes (key, family, stability, supported_backends).

✨ **Result:** The improvement in test coverage
Increased test coverage for `advanced_runtime.py` and improved code reliability by safeguarding `get_advanced_capability`'s primary intended behavior from future regressions.

---
*PR created automatically by Jules for task [14302349758961039017](https://jules.google.com/task/14302349758961039017) started by @edithatogo*