### PR TITLE
🧪 [testing improvement] Add test for get_registered_extensions in plugins.py

### DIFF
--- a/tests/unit/test_plugin_api_stability.py
+++ b/tests/unit/test_plugin_api_stability.py
@@ -67,3 +67,28 @@ def test_extension_manifest_rejects_unknown_extension_points() -> None:
             stability=StabilityTier.INTERNAL,
             extension_points=("model_registry", "remote_distribution"),
         )
+
+
+from unittest.mock import patch
+
+
+def test_get_registered_extensions_immutability() -> None:
+    """The registry accessor must return an immutable view of the registry."""
+    dummy_manifest = ExtensionManifest(
+        name="test-immutability",
+        version="1.0.0",
+        entrypoint="test.plugin:entry",
+        stability=StabilityTier.INTERNAL,
+        extension_points=("diagnostics",),
+    )
+
+    with patch.dict("innovate.plugins._REGISTERED_EXTENSIONS", {"test-immutability": dummy_manifest}, clear=True):
+        registry = get_registered_extensions()
+
+        # Verify contents
+        assert len(registry) == 1
+        assert registry["test-immutability"] is dummy_manifest
+
+        # Verify immutability
+        with pytest.raises(TypeError):
+            registry["new-plugin"] = dummy_manifest  # type: ignore[index]


### PR DESCRIPTION
🎯 **What:** The testing gap addressed: added a missing test for `get_registered_extensions` in `src/innovate/plugins.py:65`.
📊 **Coverage:** What scenarios are now tested: Validates that the dictionary of plugins returned acts as an immutable view and cannot be accidentally modified in-place, guarding against runtime leaks.
✨ **Result:** The improvement in test coverage: Added explicit tests for `get_registered_extensions`, isolating the global state modification correctly using `patch.dict`.

---
*PR created automatically by Jules for task [8102154242207454425](https://jules.google.com/task/8102154242207454425) started by @edithatogo*