### PR TITLE
🧪 Add test for deterministic order of list_advanced_capabilities

### DIFF
--- a/tests/unit/test_advanced_runtime_contracts.py
+++ b/tests/unit/test_advanced_runtime_contracts.py
@@ -157,3 +157,24 @@ def test_detect_advanced_backends_reports_numpy_available() -> None:
 
     assert detected["numpy"] is True
     assert set(detected) == {"numpy", "jax", "rust"}
+
+
+def test_list_advanced_capabilities_deterministic_order() -> None:
+    """list_advanced_capabilities should return capabilities as a tuple sorted by key."""
+    capabilities = list_advanced_capabilities()
+
+    assert isinstance(capabilities, tuple)
+    assert len(capabilities) > 0
+    assert all(isinstance(c, AdvancedCapability) for c in capabilities)
+
+    keys = [c.key for c in capabilities]
+    assert keys == sorted(keys), "Capabilities must be returned in deterministic (sorted) order"
+
+    # Optional but good: Verify it returns the full known set
+    expected_keys = {
+        "regime_ensemble",
+        "policy_scenario",
+        "streaming_update",
+        "uncertainty_calibration",
+    }
+    assert set(keys) == expected_keys


### PR DESCRIPTION
🎯 **What:** The testing gap addressed: Missing test for `list_advanced_capabilities` deterministic behavior.
📊 **Coverage:** What scenarios are now tested: Checks that the returned values are a tuple of `AdvancedCapability` instances, that their order is alphabetical by their keys, and that it retrieves all the expected keys.
✨ **Result:** The improvement in test coverage: Coverage for `src/innovate/advanced_runtime.py` is improved, closing a testing gap for a core API surface.

---
*PR created automatically by Jules for task [2441125495087159256](https://jules.google.com/task/2441125495087159256) started by @edithatogo*