### PR TITLE
🧹 [Code Health] Group uncertainty bounds into IntervalConfig

### DIFF
--- a/src/innovate/fitters/bayesian_fitter.py
+++ b/src/innovate/fitters/bayesian_fitter.py
@@ -22,6 +22,7 @@ from jax import random
 from innovate.fitters.diagnostics_contract import (
     DiagnosticsContract,
     DiagnosticsWarning,
+    IntervalConfig,
     UncertaintySummary,
     build_diagnostics_contract,
 )
@@ -310,11 +311,14 @@ class BayesianFitter:
         upper = {name: bounds[1] for name, bounds in intervals.items()}
         median = {name: stats["median"] for name, stats in summary.items()}
         samples = {name: np.asarray(values).reshape(-1) for name, values in self.posterior_samples_.items()}
-        return UncertaintySummary.posterior_summary(
+        interval = IntervalConfig(
             lower=lower,
             upper=upper,
             median=median,
             level=credible_mass,
+        )
+        return UncertaintySummary.posterior_summary(
+            interval=interval,
             samples=samples,
             note=f"{self.num_chains} chains x {self.num_samples} samples",
         )

--- a/src/innovate/fitters/diagnostics_contract.py
+++ b/src/innovate/fitters/diagnostics_contract.py
@@ -49,6 +49,16 @@ class DiagnosticsWarning:
 
 
 @dataclass(frozen=True)
+class IntervalConfig:
+    """Configuration for uncertainty intervals."""
+
+    lower: dict[str, float]
+    upper: dict[str, float]
+    median: dict[str, float] | None = None
+    level: float = 0.95
+
+
+@dataclass(frozen=True)
 class UncertaintySummary:
     """Canonical uncertainty summary for deterministic and probabilistic fitters."""
 
@@ -75,11 +85,8 @@ class UncertaintySummary:
     @classmethod
     def bootstrap_interval(
         cls,
-        lower: dict[str, float],
-        upper: dict[str, float],
-        median: dict[str, float] | None = None,
+        interval: IntervalConfig,
         *,
-        level: float = 0.95,
         note: str = "",
     ) -> UncertaintySummary:
         """Create a bootstrap interval summary."""
@@ -87,21 +94,18 @@ class UncertaintySummary:
             report_type="bootstrap_interval",
             provenance="bootstrap",
             support_level="supported",
-            level=level,
-            lower=lower,
-            upper=upper,
-            median={} if median is None else median,
+            level=interval.level,
+            lower=interval.lower,
+            upper=interval.upper,
+            median={} if interval.median is None else interval.median,
             note=note,
         )
 
     @classmethod
     def posterior_summary(
         cls,
-        lower: dict[str, float],
-        upper: dict[str, float],
-        median: dict[str, float] | None = None,
+        interval: IntervalConfig,
         *,
-        level: float = 0.95,
         samples: dict[str, np.ndarray] | None = None,
         note: str = "",
     ) -> UncertaintySummary:
@@ -110,10 +114,10 @@ class UncertaintySummary:
             report_type="posterior_summary",
             provenance="bayesian",
             support_level="supported",
-            level=level,
-            lower=lower,
-            upper=upper,
-            median={} if median is None else median,
+            level=interval.level,
+            lower=interval.lower,
+            upper=interval.upper,
+            median={} if interval.median is None else interval.median,
             samples={} if samples is None else samples,
             note=note,
         )

--- a/src/innovate/probabilistic.py
+++ b/src/innovate/probabilistic.py
@@ -9,7 +9,7 @@ from typing import Any, Mapping
 
 import numpy as np
 
-from innovate.fitters.diagnostics_contract import UncertaintySummary
+from innovate.fitters.diagnostics_contract import IntervalConfig, UncertaintySummary
 
 PROBABILISTIC_SCHEMA_MAJOR_VERSION = 1
 PROBABILISTIC_SCHEMA_MINOR_VERSION = 0
@@ -258,11 +258,14 @@ class PosteriorSamplesPayload:
             median[parameter_name] = float(np.median(draws))
             summary_samples[parameter_name] = draws
 
-        return UncertaintySummary.posterior_summary(
+        interval = IntervalConfig(
             lower=lower,
             upper=upper,
             median=median,
             level=level,
+        )
+        return UncertaintySummary.posterior_summary(
+            interval=interval,
             samples=summary_samples,
             note=(
                 f"{self.draw_shape[0]} chains x {self.draw_shape[1]} draws; "

--- a/tests/unit/test_diagnostics_contract.py
+++ b/tests/unit/test_diagnostics_contract.py
@@ -14,6 +14,7 @@ from innovate.fitters.diagnostics_contract import (
     DIAGNOSTICS_ARTIFACT_SCHEMA_VERSION,
     DiagnosticsArtifactPayload,
     DiagnosticsWarning,
+    IntervalConfig,
     UncertaintySummary,
     build_diagnostics_contract,
 )
@@ -57,16 +58,20 @@ class TestDiagnosticsContract:
         """The contract should support deterministic, bootstrap, and posterior uncertainty."""
         point = UncertaintySummary.point_estimate(provenance="deterministic")
         bootstrap = UncertaintySummary.bootstrap_interval(
-            lower={"p": 0.1, "q": 0.2},
-            upper={"p": 0.4, "q": 0.5},
-            median={"p": 0.25, "q": 0.35},
-            level=0.95,
+            interval=IntervalConfig(
+                lower={"p": 0.1, "q": 0.2},
+                upper={"p": 0.4, "q": 0.5},
+                median={"p": 0.25, "q": 0.35},
+                level=0.95,
+            )
         )
         posterior = UncertaintySummary.posterior_summary(
-            lower={"p": 0.11},
-            upper={"p": 0.43},
-            median={"p": 0.27},
-            level=0.9,
+            interval=IntervalConfig(
+                lower={"p": 0.11},
+                upper={"p": 0.43},
+                median={"p": 0.27},
+                level=0.9,
+            )
         )
 
         assert point.report_type == "point_estimate"


### PR DESCRIPTION
🎯 What: Refactored `bootstrap_interval` and `posterior_summary` to accept a new `IntervalConfig` dataclass instead of multiple individual bounds parameters (`lower`, `upper`, `median`, `level`).
💡 Why: This resolves the issue of having too many parameters on these methods, streamlining the interface by grouping related statistical bounds conceptually into a single configuration object. It also promotes consistency across the `UncertaintySummary` class since both methods share similar interval-related bounds.
✅ Verification: Ran `pre_commit_instructions` and full unit tests suite. Ensured correct instantiation of `IntervalConfig` and expected mapping to internal properties inside `bootstrap_interval` and `posterior_summary`. All local unit tests passed successfully.
✨ Result: Cleaner signature with reduced parameter count, improving maintainability and enforcing uniform configuration across interval summaries.

---
*PR created automatically by Jules for task [11907239536625971693](https://jules.google.com/task/11907239536625971693) started by @edithatogo*