### PR TITLE
test+perf: rebased Jules coverage and parallel execute_grid

### DIFF
--- a/src/innovate/scenario/execution.py
+++ b/src/innovate/scenario/execution.py
@@ -4,7 +4,9 @@ This module provides APIs for executing scenarios, tracking execution
 metadata and diagnostics, and comparing scenario results.
 """
 
+import concurrent.futures
 from datetime import UTC, datetime
+from functools import partial
 from typing import Any
 
 import numpy as np
@@ -200,6 +202,7 @@ class ScenarioExecutor:
         self,
         scenarios: list[ScenarioBase],
         notes: str | None = None,
+        max_workers: int | None = None,
     ) -> list[ScenarioExecution]:
         """Execute a grid of scenarios.
 
@@ -209,13 +212,17 @@ class ScenarioExecutor:
             List of scenarios to execute.
         notes
             Optional notes about the grid execution.
+        max_workers
+            Optional max workers for ThreadPoolExecutor.
 
         Returns
         -------
         list[ScenarioExecution]
             List of execution results.
         """
-        return [self.execute(scenario, notes=notes) for scenario in scenarios]
+        execute_partial = partial(self.execute, notes=notes)
+        with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
+            return list(executor.map(execute_partial, scenarios))
 
 
 def compare_scenarios(

--- a/tests/unit/test_advanced_runtime_contracts.py
+++ b/tests/unit/test_advanced_runtime_contracts.py
@@ -10,6 +10,8 @@ from innovate.advanced_runtime import (
     AdvancedCapability,
     AdvancedResult,
     AdvancedRuntimePolicy,
+    PolicyScenarioConfig,
+    compare_policy_scenarios,
     detect_advanced_backends,
     get_advanced_capability,
     list_advanced_capabilities,
@@ -209,3 +211,63 @@ def test_list_advanced_capabilities_deterministic_order() -> None:
         "uncertainty_calibration",
     }
     assert set(keys) == expected_keys
+
+
+def test_detect_advanced_backends_optional_backends(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Backend detection should correctly report optional backend availability."""
+    # Test when all optional backends are available
+    monkeypatch.setattr("innovate.advanced_runtime.find_spec", lambda _name: True)
+    detected_available = detect_advanced_backends()
+    assert detected_available["jax"] is True
+    assert detected_available["rust"] is True
+
+    # Test when optional backends are unavailable
+    monkeypatch.setattr("innovate.advanced_runtime.find_spec", lambda _name: None)
+    detected_unavailable = detect_advanced_backends()
+    assert detected_unavailable["jax"] is False
+    assert detected_unavailable["rust"] is False
+
+
+def test_compare_policy_scenarios_happy_path() -> None:
+    """compare_policy_scenarios correctly computes effect and relative lift."""
+    time = [1.0, 2.0, 3.0]
+    baseline = [10.0, 20.0, 30.0]
+    intervention = [10.0, 25.0, 45.0]
+
+    result = compare_policy_scenarios(
+        PolicyScenarioConfig(
+            time=time,
+            baseline=baseline,
+            intervention=intervention,
+            scenario_name="test_scenario",
+            assumptions=["a1"],
+            covariates={"cov1": [0.1, 0.2, 0.3]},
+        )
+    )
+
+    assert result.workflow == "policy_scenario"
+    assert result.stability == "stable"
+    assert result.backend == "numpy"
+    assert list(result.time) == time
+    assert list(result.mean) == intervention
+
+    metadata = result.metadata
+    assert metadata["scenario_name"] == "test_scenario"
+    assert list(metadata["baseline"]) == baseline
+    assert metadata["incremental_effect"] == 20.0
+    assert metadata["relative_lift_final"] == 0.5
+    assert list(metadata["assumptions"]) == ["a1"]
+
+
+def test_compare_policy_scenarios_zero_baseline() -> None:
+    """compare_policy_scenarios correctly handles zero final baseline value."""
+    result = compare_policy_scenarios(PolicyScenarioConfig(time=[1.0], baseline=[0.0], intervention=[5.0]))
+    assert result.metadata["relative_lift_final"] is None
+
+
+def test_compare_policy_scenarios_length_mismatch() -> None:
+    """compare_policy_scenarios validates array lengths."""
+    with pytest.raises(ValueError, match="must match time length"):
+        compare_policy_scenarios(PolicyScenarioConfig(time=[1.0, 2.0], baseline=[1.0], intervention=[1.0, 2.0]))
+    with pytest.raises(ValueError, match="must match time length"):
+        compare_policy_scenarios(PolicyScenarioConfig(time=[1.0, 2.0], baseline=[1.0, 2.0], intervention=[1.0]))

--- a/tests/unit/test_dataframe_engine_experiments.py
+++ b/tests/unit/test_dataframe_engine_experiments.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib.util
+from unittest import mock
 
 import pandas as pd
 import pytest
@@ -120,3 +121,79 @@ def test_kernel_table_payload_from_experimental_dataframe_type_error() -> None:
     """It should raise TypeError for unsupported types."""
     with pytest.raises(TypeError, match="Expected a pandas or experimental Polars DataFrame"):
         kernel_table_payload_from_experimental_dataframe([{"time": 1.0}])
+
+
+def test_describe_dataframe_engine_experiments_comprehensive() -> None:
+    """The describe_dataframe_engine_experiments function should return the complete contract."""
+    contract = describe_dataframe_engine_experiments()
+
+    assert contract["schema_version"] == kernel.KERNEL_SCHEMA_VERSION
+    assert contract["default_surface"] == "pandas+pyarrow"
+
+    assert "pandas" in contract["inventory"]
+    assert "pyarrow" in contract["inventory"]
+    assert "polars" in contract["inventory"]
+
+    assert "Python-facing tabular outputs" in contract["inventory"]["pandas"]
+    assert "optional downstream Arrow consumer" in contract["inventory"]["polars"]
+
+    assert "benchmark_corpus_metadata" in contract["candidate_workloads"]
+    assert "diagnostics_artifact_tables" in contract["candidate_workloads"]
+
+    assert "row_count" in contract["metrics"]
+    assert "column_count" in contract["metrics"]
+    assert "correctness_hash" in contract["metrics"]
+    assert "wall_time_ms" in contract["metrics"]
+    assert "peak_memory_bytes" in contract["metrics"]
+
+    assert contract["optional_engines"]["polars"]["support_tier"] == "experimental"
+    assert contract["optional_engines"]["polars"]["dependency_extra"] == "dataframe"
+    assert contract["optional_engines"]["polars"]["fallback"] == "pandas+pyarrow"
+
+    assert contract["public_contract"] == "kernel schema and Arrow-compatible payloads"
+
+    assert "Polars lazy query plans" in contract["blocked_public_contracts"]
+    assert "engine-specific expression trees" in contract["blocked_public_contracts"]
+    assert "XLA compiler internals" in contract["blocked_public_contracts"]
+
+    assert "correctness parity with pandas+pyarrow" in contract["promotion_criteria"]
+    assert "reproducible benchmark evidence" in contract["promotion_criteria"]
+    assert "no public API drift" in contract["promotion_criteria"]
+    assert "explicit optional dependency gate" in contract["promotion_criteria"]
+
+    assert (
+        contract["attribution"]["tabular_execution"] == "DataFrame engine, query planning, and Arrow table conversion"
+    )
+    assert contract["attribution"]["separate_from"] == "XLA-backed numerical kernels"
+
+
+def test_unsupported_engine_raises_value_error() -> None:
+    """An explicit request for an unknown engine should fail fast with a ValueError."""
+    payload = _table_payload()
+    with pytest.raises(ValueError, match="Unsupported DataFrame engine: unsupported"):
+        kernel_table_payload_to_experimental_dataframe(payload, engine="unsupported")
+
+
+def test_dataframe_engine_available_returns_true_for_pandas_engines() -> None:
+    """Pandas variants should always report as available without import checks."""
+    assert dataframe_engine_available("pandas") is True
+    assert dataframe_engine_available("pandas+pyarrow") is True
+    assert dataframe_engine_available("pandas-pyarrow") is True
+    assert dataframe_engine_available("PANDAS") is True
+
+
+def test_dataframe_engine_available_checks_importlib_for_polars() -> None:
+    """Polars availability should depend on whether the module can be found."""
+    with mock.patch("importlib.util.find_spec", return_value=mock.Mock()) as find_spec_mock:
+        assert dataframe_engine_available("polars") is True
+        find_spec_mock.assert_called_once_with("polars")
+
+    with mock.patch("importlib.util.find_spec", return_value=None) as find_spec_mock:
+        assert dataframe_engine_available("polars") is False
+        find_spec_mock.assert_called_once_with("polars")
+
+
+def test_dataframe_engine_available_raises_on_unsupported_engine() -> None:
+    """Unknown engines should raise ValueError instead of returning False."""
+    with pytest.raises(ValueError, match="Unsupported DataFrame engine: duckdb"):
+        dataframe_engine_available("duckdb")

--- a/tests/unit/test_kernel_contract.py
+++ b/tests/unit/test_kernel_contract.py
@@ -313,3 +313,53 @@ def test_discover_models_returns_correct_response_structure() -> None:
     assert response.models[0].key == "test_model"
     assert response.models[0].family == "test_family"
     assert response.models[0].import_path == "dummy.path.TestModel"
+
+
+def test_discover_models_returns_valid_response(monkeypatch) -> None:
+    """discover_models should return a valid response reflecting the model registry."""
+    from innovate import kernel
+    from innovate.capabilities import ModelCapability
+
+    mock_capability = ModelCapability(
+        key="mock_model",
+        family="mock_family",
+        import_path="mock.path",
+        supports_covariates=False,
+    )
+    monkeypatch.setattr("innovate.kernel.get_model_registry", lambda: {"mock_model": mock_capability})
+
+    response = kernel.discover_models()
+
+    assert isinstance(response, kernel.KernelDiscoveryResponse)
+    assert response.schema_version == kernel.KERNEL_SCHEMA_VERSION
+    assert len(response.models) == 1
+
+    record = response.models[0]
+    assert isinstance(record, kernel.KernelDiscoveryRecord)
+    assert record.key == "mock_model"
+    assert record.family == "mock_family"
+    assert record.import_path == "mock.path"
+    assert record.supports_covariates is False
+    assert record.stability == "stable"
+    assert record.supported_backends == ("numpy", "jax")
+
+
+def test_discover_models_empty_registry(monkeypatch) -> None:
+    """discover_models should handle an empty model registry gracefully."""
+    from innovate import kernel
+
+    monkeypatch.setattr("innovate.kernel.get_model_registry", lambda: {})
+    response = kernel.discover_models()
+
+    assert isinstance(response, kernel.KernelDiscoveryResponse)
+    assert response.schema_version == kernel.KERNEL_SCHEMA_VERSION
+    assert response.models == ()
+
+
+def test_list_kernel_operations() -> None:
+    """list_kernel_operations should return the documented public operations."""
+    from innovate import kernel
+
+    operations = kernel.list_kernel_operations()
+    assert isinstance(operations, tuple)
+    assert "discover_models" in operations

--- a/tests/unit/test_plugin_api_stability.py
+++ b/tests/unit/test_plugin_api_stability.py
@@ -92,3 +92,55 @@ def test_get_registered_extensions_immutability() -> None:
         # Verify immutability
         with pytest.raises(TypeError):
             registry["new-plugin"] = dummy_manifest  # type: ignore[index]
+
+
+def test_extension_manifest_rejects_empty_name() -> None:
+    with pytest.raises(ValueError, match="Extension manifest name must be non-empty."):
+        ExtensionManifest(
+            name="",
+            version="1.0.0",
+            entrypoint="demo.plugin:register",
+            stability=StabilityTier.PROVISIONAL,
+            extension_points=("model_registry",),
+        )
+
+
+def test_extension_manifest_rejects_empty_version() -> None:
+    with pytest.raises(ValueError, match="Extension manifest version must be non-empty."):
+        ExtensionManifest(
+            name="demo-plugin",
+            version="",
+            entrypoint="demo.plugin:register",
+            stability=StabilityTier.PROVISIONAL,
+            extension_points=("model_registry",),
+        )
+
+
+def test_extension_manifest_rejects_invalid_entrypoint() -> None:
+    with pytest.raises(ValueError, match="Extension manifest entrypoint must be in 'module:callable' format."):
+        ExtensionManifest(
+            name="demo-plugin",
+            version="1.0.0",
+            entrypoint="demo.plugin",
+            stability=StabilityTier.PROVISIONAL,
+            extension_points=("model_registry",),
+        )
+    with pytest.raises(ValueError, match="Extension manifest entrypoint must be in 'module:callable' format."):
+        ExtensionManifest(
+            name="demo-plugin",
+            version="1.0.0",
+            entrypoint="",
+            stability=StabilityTier.PROVISIONAL,
+            extension_points=("model_registry",),
+        )
+
+
+def test_extension_manifest_rejects_empty_extension_points() -> None:
+    with pytest.raises(ValueError, match="Extension manifest extension_points must be non-empty."):
+        ExtensionManifest(
+            name="demo-plugin",
+            version="1.0.0",
+            entrypoint="demo.plugin:register",
+            stability=StabilityTier.PROVISIONAL,
+            extension_points=(),
+        )


### PR DESCRIPTION
## Summary
- Rebases remaining Jules test/perf work onto current main
- `compare_policy_scenarios` unit tests use `PolicyScenarioConfig`
- ExtensionManifest validation, discover_models edges, `list_kernel_operations`
- `dataframe_engine_available` coverage
- `ScenarioExecutor.execute_grid` ThreadPoolExecutor + `max_workers`

## Test plan
- [x] Local pytest on new/changed tests
- [ ] CI green