### PR TITLE
test+perf: rebased engine tests and parallel execute_grid

### DIFF
--- a/src/innovate/scenario/execution.py
+++ b/src/innovate/scenario/execution.py
@@ -4,7 +4,9 @@ This module provides APIs for executing scenarios, tracking execution
 metadata and diagnostics, and comparing scenario results.
 """
 
+import concurrent.futures
 from datetime import UTC, datetime
+from functools import partial
 from typing import Any
 
 import numpy as np
@@ -200,6 +202,7 @@ class ScenarioExecutor:
         self,
         scenarios: list[ScenarioBase],
         notes: str | None = None,
+        max_workers: int | None = None,
     ) -> list[ScenarioExecution]:
         """Execute a grid of scenarios.
 
@@ -209,13 +212,17 @@ class ScenarioExecutor:
             List of scenarios to execute.
         notes
             Optional notes about the grid execution.
+        max_workers
+            Optional max workers for ThreadPoolExecutor.
 
         Returns
         -------
         list[ScenarioExecution]
             List of execution results.
         """
-        return [self.execute(scenario, notes=notes) for scenario in scenarios]
+        execute_partial = partial(self.execute, notes=notes)
+        with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
+            return list(executor.map(execute_partial, scenarios))
 
 
 def compare_scenarios(

--- a/tests/unit/test_dataframe_engine_experiments.py
+++ b/tests/unit/test_dataframe_engine_experiments.py
@@ -120,3 +120,28 @@ def test_kernel_table_payload_from_experimental_dataframe_type_error() -> None:
     """It should raise TypeError for unsupported types."""
     with pytest.raises(TypeError, match="Expected a pandas or experimental Polars DataFrame"):
         kernel_table_payload_from_experimental_dataframe([{"time": 1.0}])
+
+
+def test_dataframe_engine_available_returns_true_for_pandas_engines() -> None:
+    """Pandas variants should always report as available without import checks."""
+    assert dataframe_engine_available("pandas") is True
+    assert dataframe_engine_available("pandas+pyarrow") is True
+    assert dataframe_engine_available("pandas-pyarrow") is True
+    assert dataframe_engine_available("PANDAS") is True
+
+
+def test_dataframe_engine_available_checks_importlib_for_polars() -> None:
+    """Polars availability should depend on whether the module can be found."""
+    with mock.patch("importlib.util.find_spec", return_value=mock.Mock()) as find_spec_mock:
+        assert dataframe_engine_available("polars") is True
+        find_spec_mock.assert_called_once_with("polars")
+
+    with mock.patch("importlib.util.find_spec", return_value=None) as find_spec_mock:
+        assert dataframe_engine_available("polars") is False
+        find_spec_mock.assert_called_once_with("polars")
+
+
+def test_dataframe_engine_available_raises_on_unsupported_engine() -> None:
+    """Unknown engines should raise ValueError instead of returning False."""
+    with pytest.raises(ValueError, match="Unsupported DataFrame engine: duckdb"):
+        dataframe_engine_available("duckdb")

--- a/tests/unit/test_kernel_contract.py
+++ b/tests/unit/test_kernel_contract.py
@@ -313,3 +313,13 @@ def test_discover_models_returns_correct_response_structure() -> None:
     assert response.models[0].key == "test_model"
     assert response.models[0].family == "test_family"
     assert response.models[0].import_path == "dummy.path.TestModel"
+
+
+def test_list_kernel_operations() -> None:
+    """list_kernel_operations should return the canonical tuple of kernel operations."""
+    from innovate import kernel
+
+    operations = kernel.list_kernel_operations()
+    assert isinstance(operations, tuple)
+    assert all(isinstance(op, str) for op in operations)
+    assert operations == kernel.KERNEL_OPERATIONS


### PR DESCRIPTION
## Summary
- Rebases remaining useful CONFLICTING Jules PRs onto main
- Tests for `dataframe_engine_available` and `list_kernel_operations`
- `ScenarioExecutor.execute_grid` uses ThreadPoolExecutor with optional `max_workers`

## Supersedes
#121, #123, #175. Closes #156 as already implemented on main.