### PR TITLE
🧪 [testing improvement] Cover ValueError in _is_schema_version_compatible

### DIFF
--- a/tests/unit/test_kernel_contract.py
+++ b/tests/unit/test_kernel_contract.py
@@ -283,6 +283,8 @@ def test_kernel_contract_schema_version_compatibility_helper() -> None:
     assert not kernel._is_schema_version_compatible("1.2", "1.0")
     assert not kernel._is_schema_version_compatible("2.0", "1.0")
     assert not kernel._is_schema_version_compatible("1", "1.0")
+    assert not kernel._is_schema_version_compatible("invalid", "1.0")
+    assert not kernel._is_schema_version_compatible("1.0", "invalid")
 
 
 def test_discover_models_returns_correct_response_structure() -> None:


### PR DESCRIPTION
🎯 **What:** The `_is_schema_version_compatible` function handles `ValueError` when invalid schema versions are passed, but this error path wasn't covered by tests.
📊 **Coverage:** Added test cases with malformed schema versions to `test_kernel_contract_schema_version_compatibility_helper` (passing an invalid string to both the `schema_version` argument and `supported_version` argument).
✨ **Result:** Improved test coverage by explicitly validating that invalid schema version strings are safely handled and return `False` rather than crashing.

---
*PR created automatically by Jules for task [7791551276625451882](https://jules.google.com/task/7791551276625451882) started by @edithatogo*