### PR TITLE
🔒 [security] Fix missing input validation in CausalModel.from_json

### DIFF
--- a/src/innovate/causal/policy.py
+++ b/src/innovate/causal/policy.py
@@ -202,8 +202,11 @@ class CausalModel:
         if not isinstance(data["causal_model"], dict):
             raise PolicyEvaluationError("'causal_model' must be a dictionary")
 
-        intervention = InterventionContract(**data["intervention"])
-        causal_model = CausalModelContract(**data["causal_model"])
+        try:
+            intervention = InterventionContract(**data["intervention"])
+            causal_model = CausalModelContract(**data["causal_model"])
+        except TypeError as e:
+            raise PolicyEvaluationError(f"Invalid model specification: {e}")
         return cls(intervention=intervention, causal_model=causal_model)
 
     def to_arrow(self) -> pa.Table:

--- a/tests/unit/test_causal_policy_security.py
+++ b/tests/unit/test_causal_policy_security.py
@@ -83,3 +83,44 @@ def test_causal_model_from_json_causal_model_not_dict():
     )
     with pytest.raises(PolicyEvaluationError, match="'causal_model' must be a dictionary"):
         CausalModel.from_json(causal_model_not_dict)
+
+
+def test_causal_model_from_json_extra_keys_rejected():
+    invalid_json = json.dumps(
+        {
+            "intervention": {
+                "name": "test_intervention",
+                "timing": "post",
+                "comparator": "control",
+                "malicious_key": "injected_value",
+            },
+            "causal_model": {
+                "name": "test_causal_model",
+                "treatment_variable": "treatment",
+                "outcome_variable": "outcome",
+                "confounders": ["c1", "c2"],
+            },
+        }
+    )
+    with pytest.raises(PolicyEvaluationError, match="Invalid model specification"):
+        CausalModel.from_json(invalid_json)
+
+
+def test_causal_model_from_json_missing_keys_rejected():
+    invalid_json = json.dumps(
+        {
+            "intervention": {
+                "timing": "post",
+                "comparator": "control",
+            },
+            "causal_model": {
+                "name": "test_causal_model",
+                "treatment_variable": "treatment",
+                "outcome_variable": "outcome",
+                "confounders": ["c1", "c2"],
+            },
+        }
+    )
+    # Missing "name" in intervention contract
+    with pytest.raises(PolicyEvaluationError, match="Invalid model specification"):
+        CausalModel.from_json(invalid_json)


### PR DESCRIPTION
🎯 **What:**
The `CausalModel.from_json` method directly unpacked user-provided JSON payloads via `**data["intervention"]` and `**data["causal_model"]` without sufficient validation. This caused unexpected/missing keys to trigger a `TypeError` exception when initializing the respective dataclasses.

⚠️ **Risk:**
If a user submits an improperly formatted payload (e.g. missing required keys or containing extra/unexpected keys), the code would crash with a generic `TypeError` due to dataclass constructor constraints. This lack of explicit error handling poses a potential Denial of Service (DoS) risk where unhandled exceptions could disrupt application functionality when parsing untrusted JSON.

🛡️ **Solution:**
The fix wraps the instantiation of `InterventionContract` and `CausalModelContract` inside a `try...except TypeError` block. Any `TypeError` encountered during the dataclass initialization is now caught and properly re-raised as a structured `PolicyEvaluationError`, securely handling bad payloads without causing an unhandled application crash. Additional unit tests were added to specifically verify that missing required keys and unexpected extra keys are explicitly rejected with the custom error.

---
*PR created automatically by Jules for task [4507279940254331860](https://jules.google.com/task/4507279940254331860) started by @edithatogo*