### PR TITLE
🔒 [security fix] fix insecure random number generator in ABM

### DIFF
--- a/src/innovate/abm/model.py
+++ b/src/innovate/abm/model.py
@@ -16,9 +16,12 @@ class InnovationModel(Model):
         # Create agents
         for i in range(self.num_agents):
             agent = InnovationAgent(i, self)
-            # Add the agent to a random grid cell
-            x = self.random.randrange(self.grid.width)
-            y = self.random.randrange(self.grid.height)
+            # Add the agent to a random grid cell.
+            # We use standard pseudo-random number generation (self.random)
+            # to preserve simulation reproducibility and determinism in Mesa ABMs.
+            # This is not a cryptographic context.
+            x = self.random.randrange(self.grid.width)  # nosec B311
+            y = self.random.randrange(self.grid.height)  # nosec B311
             self.grid.place_agent(agent, (x, y))
 
     def step(self):


### PR DESCRIPTION
🎯 **What:** 
Added `# nosec B311` suppression and an inline explanation to `self.random.randrange()` calls in `src/innovate/abm/model.py`.

⚠️ **Risk:** 
Security scanners (like Bandit) flag `random.randrange` as an insecure random number generator. While true for cryptographic operations, in the context of scientific simulations and Agent-Based Models (ABM) using Mesa, replacing this with a secure generator (like `secrets`) would destroy simulation reproducibility and determinism.

🛡️ **Solution:** 
Treat this as a false positive by explicitly documenting that this is a non-cryptographic context required for simulation determinism. Added Bandit suppression tags to silence the security warning while preserving existing functionality and reproducibility.

---
*PR created automatically by Jules for task [8188767730276966325](https://jules.google.com/task/8188767730276966325) started by @edithatogo*