### PR TITLE
🔒 Fix hardcoded authorization context in RemoteExecutionPolicy

### DIFF
--- a/src/innovate/remote_execution.py
+++ b/src/innovate/remote_execution.py
@@ -23,8 +23,8 @@ class RemoteExecutionContext:
     request_id: str
     tenant_id: str
     principal: str
+    auth_scope: str
     trace_id: str = ""
-    auth_scope: str = "kernel:execute"
     data_retention: str = "ephemeral"
 
     def __post_init__(self) -> None:
@@ -51,8 +51,8 @@ class RemoteExecutionContext:
             request_id=str(data["request_id"]),
             tenant_id=str(data["tenant_id"]),
             principal=str(data["principal"]),
+            auth_scope=str(data["auth_scope"]),
             trace_id=str(data.get("trace_id", "")),
-            auth_scope=str(data.get("auth_scope", "kernel:execute")),
             data_retention=str(data.get("data_retention", "ephemeral")),
         )
 
@@ -61,6 +61,7 @@ class RemoteExecutionContext:
 class RemoteExecutionPolicy:
     """Local policy used by hosted adapters before dispatching kernel requests."""
 
+    required_auth_scope: str
     eligible_operations: tuple[str, ...] = (
         kernel.KernelOperation.DISCOVER_MODELS.value,
         kernel.KernelOperation.PREDICT_MODEL.value,
@@ -69,7 +70,6 @@ class RemoteExecutionPolicy:
         kernel.KernelOperation.DIAGNOSE_MODEL.value,
     )
     local_only_by_default: tuple[str, ...] = (kernel.KernelOperation.FIT_MODEL.value,)
-    required_auth_scope: str = "kernel:execute"
     max_payload_bytes: int = 1_000_000
     data_retention: str = "ephemeral"
 
@@ -166,7 +166,7 @@ class InProcessRemoteExecutor:
         runtime: str = "python",
         backend: str = "numpy_scipy",
     ) -> None:
-        self.policy = policy or RemoteExecutionPolicy()
+        self.policy = policy or RemoteExecutionPolicy(required_auth_scope="kernel:execute")
         self.runtime = runtime
         self.backend = backend
 
@@ -234,7 +234,7 @@ class InProcessRemoteExecutor:
 
 def describe_remote_execution_contract() -> dict[str, Any]:
     """Describe remote execution boundaries, security, and observability requirements."""
-    policy = RemoteExecutionPolicy()
+    policy = RemoteExecutionPolicy(required_auth_scope="kernel:execute")
     return {
         "schema_version": kernel.KERNEL_SCHEMA_VERSION,
         "eligible_operations": policy.eligible_operations,

--- a/tests/unit/test_remote_execution.py
+++ b/tests/unit/test_remote_execution.py
@@ -37,6 +37,7 @@ def test_in_process_remote_executor_preserves_kernel_schema_and_correlation() ->
             request_id="req-001",
             tenant_id="tenant-a",
             principal="service-user",
+            auth_scope="kernel:execute",
             trace_id="trace-001",
         ),
     )
@@ -56,7 +57,10 @@ def test_in_process_remote_executor_preserves_kernel_schema_and_correlation() ->
 def test_remote_executor_returns_structured_error_for_disallowed_operation() -> None:
     """Remote policy failures should be structured and language-binding friendly."""
     executor = InProcessRemoteExecutor(
-        policy=RemoteExecutionPolicy(eligible_operations=("discover_models",)),
+        policy=RemoteExecutionPolicy(
+            required_auth_scope="kernel:execute",
+            eligible_operations=("discover_models",),
+        ),
     )
     request = RemoteExecutionRequest(
         kernel_request=kernel.KernelRequest(
@@ -68,6 +72,7 @@ def test_remote_executor_returns_structured_error_for_disallowed_operation() -> 
             request_id="req-denied",
             tenant_id="tenant-a",
             principal="service-user",
+            auth_scope="kernel:execute",
         ),
     )
 
@@ -92,9 +97,40 @@ def test_remote_execution_request_round_trips_from_dict() -> None:
             request_id="req-roundtrip",
             tenant_id="tenant-a",
             principal="service-user",
+            auth_scope="kernel:execute",
         ),
     )
 
     restored = RemoteExecutionRequest.from_dict(request.to_dict())
 
     assert restored == request
+
+
+def test_remote_execution_policy_enforces_auth_scope() -> None:
+    """The local adapter should deny requests if the context auth_scope does not match the policy."""
+    executor = InProcessRemoteExecutor(
+        policy=RemoteExecutionPolicy(
+            required_auth_scope="kernel:execute_sensitive",
+            eligible_operations=("discover_models",),
+        ),
+    )
+    request = RemoteExecutionRequest(
+        kernel_request=kernel.KernelRequest(
+            operation=kernel.KernelOperation.DISCOVER_MODELS.value,
+            model_key=None,
+            payload={},
+        ),
+        context=RemoteExecutionContext(
+            request_id="req-auth-fail",
+            tenant_id="tenant-a",
+            principal="service-user",
+            auth_scope="kernel:execute",
+        ),
+    )
+
+    response = executor.execute(request)
+
+    assert response.status == "error"
+    assert response.kernel_response.error is not None
+    assert response.kernel_response.error.code == kernel.KernelErrorCode.UNSUPPORTED_OPERATION.value
+    assert "auth_scope is not authorized" in response.kernel_response.error.message


### PR DESCRIPTION
🎯 **What:**
The `RemoteExecutionContext` and `RemoteExecutionPolicy` classes were configured to use a hardcoded default `auth_scope` of `"kernel:execute"`. This commit removes these default values, making the authorization scope explicitly required on instantiation.

⚠️ **Risk:**
With hardcoded defaults, it was highly likely that consumers of the policy or developers creating execution contexts could inadvertently allow or accept requests without explicitly declaring and verifying correct intent or required scopes, reducing the security posture. This could easily lead to an exploit where an attacker leverages an unverified or inadvertently authorized request.

🛡️ **Solution:**
Removed the default value for `auth_scope` in both `RemoteExecutionContext` and `RemoteExecutionPolicy`, ensuring they are strictly required parameters. Any existing invocations in codebase and tests have been updated to explicitly provide the `"kernel:execute"` scope where needed. A new test validates that the local adapter rejects contexts lacking the matching explicitly defined policy scope.

---
*PR created automatically by Jules for task [11165465247488819551](https://jules.google.com/task/11165465247488819551) started by @edithatogo*