### PR TITLE
🔒 [Fix insecure random number generator in agent placement]

### DIFF
--- a/commit_message.txt
+++ b/commit_message.txt
@@ -1,0 +1,5 @@
+🎯 **What:** The initial placement of agents on the grid was utilizing `self.random.randrange`, which relies on the standard Python pseudo-random number generator.
+
+⚠️ **Risk:** The standard pseudo-random number generator is predictable and insecure, making it vulnerable to exploitation where an attacker could potentially guess or manipulate the sequence of generated numbers, thus predicting or influencing the starting state of agents within the simulation.
+
+🛡️ **Solution:** Replaced `self.random.randrange` with `secrets.randbelow`. The `secrets` module provides a cryptographically strong random number generator suitable for securely generating random values. This addresses the vulnerability by ensuring that initial placement coordinates are unpredictable and robust against attacks.

--- a/src/innovate/abm/model.py
+++ b/src/innovate/abm/model.py
@@ -1,3 +1,5 @@
+import secrets
+
 from mesa import Model
 from mesa.space import MultiGrid
 
@@ -17,8 +19,8 @@ class InnovationModel(Model):
         for i in range(self.num_agents):
             agent = InnovationAgent(i, self)
             # Add the agent to a random grid cell
-            x = self.random.randrange(self.grid.width)
-            y = self.random.randrange(self.grid.height)
+            x = secrets.randbelow(self.grid.width)
+            y = secrets.randbelow(self.grid.height)
             self.grid.place_agent(agent, (x, y))
 
     def step(self):


### PR DESCRIPTION
🎯 **What:** The initial placement of agents on the grid was utilizing `self.random.randrange`, which relies on the standard Python pseudo-random number generator.

⚠️ **Risk:** The standard pseudo-random number generator is predictable and insecure, making it vulnerable to exploitation where an attacker could potentially guess or manipulate the sequence of generated numbers, thus predicting or influencing the starting state of agents within the simulation.

🛡️ **Solution:** Replaced `self.random.randrange` with `secrets.randbelow`. The `secrets` module provides a cryptographically strong random number generator suitable for securely generating random values. This addresses the vulnerability by ensuring that initial placement coordinates are unpredictable and robust against attacks.

---
*PR created automatically by Jules for task [5507265082897049461](https://jules.google.com/task/5507265082897049461) started by @edithatogo*