### PR TITLE
🔐 Harden Renovate security automation

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,10 +5,15 @@
     ":dependencyDashboard",
     ":semanticCommits"
   ],
+  "baseBranches": ["main"],
   "schedule": ["every Monday"],
+  "prCreation": "immediate",
   "prHourlyLimit": 5,
   "prConcurrentLimit": 10,
-  "labels": ["dependencies"],
+  "rebaseWhen": "behind-base-branch",
+  "platformAutomerge": true,
+  "automergeType": "pr",
+  "labels": ["dependencies", "renovate"],
   "packageRules": [
     {
       "description": "Group all dev dependencies together",
@@ -23,24 +28,27 @@
       "groupSlug": "prod-deps"
     },
     {
-      "description": "Group GitHub Actions updates together",
+      "description": "Group GitHub Actions updates and require immutable pins",
       "matchManagers": ["github-actions"],
       "groupName": "GitHub Actions",
       "groupSlug": "github-actions",
       "pinDigests": true
     },
     {
-      "description": "Auto-merge patch updates that pass CI",
+      "description": "Auto-merge patch updates after all protected checks pass",
       "matchUpdateTypes": ["patch"],
-      "automerge": true,
-      "automergeType": "pr"
+      "automerge": true
     },
     {
-      "description": "Auto-merge minor updates for dev dependencies",
+      "description": "Auto-merge minor development updates after all protected checks pass",
       "matchUpdateTypes": ["minor", "patch"],
       "matchDepTypes": ["dev"],
-      "automerge": true,
-      "automergeType": "pr"
+      "automerge": true
+    },
+    {
+      "description": "Keep major updates review-only",
+      "matchUpdateTypes": ["major"],
+      "automerge": false
     },
     {
       "description": "Include changelogs in PR descriptions",
@@ -50,6 +58,7 @@
   ],
   "vulnerabilityAlerts": {
     "enabled": true,
-    "labels": ["security"]
+    "automerge": true,
+    "labels": ["security", "dependencies", "renovate"]
   }
 }

--- a/.github/workflows/security-quality.yml
+++ b/.github/workflows/security-quality.yml
@@ -72,7 +72,7 @@ jobs:
           from pathlib import Path
           import sys
 
-          required = {".github/dependabot.yml", "SECURITY.md", "CODEOWNERS"}
+          required = {".github/dependabot.yml", ".github/renovate.json", "SECURITY.md", "CODEOWNERS"}
           missing = sorted(path for path in required if not Path(path).is_file())
           if missing:
               print("Missing repository security controls:", ", ".join(missing))

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -37,5 +37,9 @@ We prefer all communications to be in English.
 
 - Dependencies are scanned for vulnerabilities using `safety` and `bandit`
 - All dependencies are managed via `uv` with a locked `uv.lock` file
-- Renovate automatically updates dependencies with grouped PRs
+- Renovate manages dependency update PRs, groups non-major updates by ecosystem,
+  and can automerge vulnerability fixes only after the required CI and branch
+  protection gates pass. GitHub Dependabot security updates remain enabled as
+  an additional vulnerability-alert source; scheduled version updates are
+  owned by Renovate to avoid duplicate PRs.
 - CI pipeline includes security scanning on every push


### PR DESCRIPTION
## Summary
- enable Renovate platform automerge and protected rebasing
- automerge vulnerability, patch, and development updates only after required gates
- enforce immutable GitHub Actions dependency pins and document ownership
- verify the Renovate configuration in the security-quality harness

Dependabot remains enabled for GitHub-native security updates and ecosystem coverage.