### PR TITLE
🔒 Fix insecure random number generator in ABM model

### DIFF
--- a/pr_description.txt
+++ b/pr_description.txt
@@ -1,0 +1,10 @@
+🔒 [fix secure random abm]
+
+🎯 **What:** The vulnerability fixed
+Addressed an insecure random number generator vulnerability in the ABM model placement code (`src/innovate/abm/model.py`). The code previously used the standard pseudorandom generator `random.randrange()` via `mesa`'s `self.random` when calculating agent grid coordinates.
+
+⚠️ **Risk:** The potential impact if left unfixed
+While typically used for deterministic simulations, standard PRNGs are predictable and not suitable for security-sensitive contexts. Using them could potentially allow an attacker to predict or manipulate agent placements in environments where this model might be exposed to untrusted input or influence critical decisions.
+
+🛡️ **Solution:** How the fix addresses the vulnerability
+Replaced the use of `self.random.randrange()` with the cryptographically secure `secrets.randbelow()` module to compute random X and Y coordinates. While this sacrifices standard deterministic seeding capability, it meets the strict security requirement of avoiding insecure PRNGs in this context.

--- a/src/innovate/abm/model.py
+++ b/src/innovate/abm/model.py
@@ -1,3 +1,5 @@
+import secrets
+
 from mesa import Model
 from mesa.space import MultiGrid
 
@@ -17,8 +19,8 @@ class InnovationModel(Model):
         for i in range(self.num_agents):
             agent = InnovationAgent(i, self)
             # Add the agent to a random grid cell
-            x = self.random.randrange(self.grid.width)
-            y = self.random.randrange(self.grid.height)
+            x = secrets.randbelow(self.grid.width)
+            y = secrets.randbelow(self.grid.height)
             self.grid.place_agent(agent, (x, y))
 
     def step(self):


### PR DESCRIPTION
🎯 **What:** Addressed an insecure random number generator vulnerability in the ABM model placement code (`src/innovate/abm/model.py`). The code previously used the standard pseudorandom generator `random.randrange()` via `mesa`'s `self.random` when calculating agent grid coordinates.

⚠️ **Risk:** While typically used for deterministic simulations, standard PRNGs are predictable and not suitable for security-sensitive contexts. Using them could potentially allow an attacker to predict or manipulate agent placements in environments where this model might be exposed to untrusted input or influence critical decisions.

🛡️ **Solution:** Replaced the use of `self.random.randrange()` with the cryptographically secure `secrets.randbelow()` module to compute random X and Y coordinates. While this sacrifices standard deterministic seeding capability, it meets the strict security requirement of avoiding insecure PRNGs in this context.

---
*PR created automatically by Jules for task [4467248897244001018](https://jules.google.com/task/4467248897244001018) started by @edithatogo*