### PR TITLE
🧹 [code health improvement] Format causal policy security fix in PR #318

### DIFF
--- a/src/innovate/causal/policy.py
+++ b/src/innovate/causal/policy.py
@@ -7,12 +7,14 @@ sensitivity analysis for unmeasured confounding.
 
 from __future__ import annotations
 
+import dataclasses
 import json
 from dataclasses import asdict, dataclass, field
 from typing import Any
 
 import numpy as np
 import pyarrow as pa
+from pydantic import TypeAdapter, ValidationError
 
 
 class PolicyEvaluationError(Exception):
@@ -202,8 +204,26 @@ class CausalModel:
         if not isinstance(data["causal_model"], dict):
             raise PolicyEvaluationError("'causal_model' must be a dictionary")
 
-        intervention = InterventionContract(**data["intervention"])
-        causal_model = CausalModelContract(**data["causal_model"])
+        # Validate that no unknown fields are provided for intervention
+        intervention_fields = {f.name for f in dataclasses.fields(InterventionContract)}
+        intervention_unknown = set(data["intervention"].keys()) - intervention_fields  # type: ignore
+        if intervention_unknown:
+            unknown_keys: list[str] = list(intervention_unknown)  # type: ignore
+            raise PolicyEvaluationError(f"Unknown fields in 'intervention': {', '.join(sorted(unknown_keys))}")
+
+        # Validate that no unknown fields are provided for causal_model
+        cm_fields = {f.name for f in dataclasses.fields(CausalModelContract)}
+        cm_unknown = set(data["causal_model"].keys()) - cm_fields  # type: ignore
+        if cm_unknown:
+            cm_unknown_keys: list[str] = list(cm_unknown)  # type: ignore
+            raise PolicyEvaluationError(f"Unknown fields in 'causal_model': {', '.join(sorted(cm_unknown_keys))}")
+
+        try:
+            intervention = TypeAdapter(InterventionContract).validate_python(data["intervention"])
+            causal_model = TypeAdapter(CausalModelContract).validate_python(data["causal_model"])
+        except ValidationError as e:
+            raise PolicyEvaluationError(f"Data validation error: {e}")
+
         return cls(intervention=intervention, causal_model=causal_model)
 
     def to_arrow(self) -> pa.Table:

--- a/tests/unit/test_causal_policy_evaluation.py
+++ b/tests/unit/test_causal_policy_evaluation.py
@@ -622,3 +622,76 @@ class TestJSONArrowCompatibility:
         # Should be able to export results as Arrow
         table = estimator.results_to_arrow(result)
         assert table.num_rows > 0
+
+
+def test_causal_model_from_json_extra_fields():
+    """Test that `from_json` securely rejects arbitrary extra fields to prevent injection."""
+    from src.innovate.causal.policy import CausalModel, PolicyEvaluationError
+
+    # Valid causal model structure with an extra 'hack' key in intervention
+    json_str_intervention_hack = """{
+        "intervention": {
+            "name": "test",
+            "timing": "post",
+            "comparator": "control",
+            "hack": "malicious_payload"
+        },
+        "causal_model": {
+            "name": "cm",
+            "treatment_variable": "t",
+            "outcome_variable": "o",
+            "confounders": ["c"]
+        }
+    }"""
+
+    import pytest
+
+    with pytest.raises(PolicyEvaluationError) as excinfo:
+        CausalModel.from_json(json_str_intervention_hack)
+    assert "Unknown fields in 'intervention': hack" in str(excinfo.value)
+
+    # Valid causal model structure with an extra 'hack' key in causal_model
+    json_str_causal_hack = """{
+        "intervention": {
+            "name": "test",
+            "timing": "post",
+            "comparator": "control"
+        },
+        "causal_model": {
+            "name": "cm",
+            "treatment_variable": "t",
+            "outcome_variable": "o",
+            "confounders": ["c"],
+            "hack": "malicious_payload"
+        }
+    }"""
+
+    with pytest.raises(PolicyEvaluationError) as excinfo:
+        CausalModel.from_json(json_str_causal_hack)
+    assert "Unknown fields in 'causal_model': hack" in str(excinfo.value)
+
+
+def test_causal_model_from_json_invalid_types():
+    """Test that `from_json` securely enforces type checks."""
+    from src.innovate.causal.policy import CausalModel, PolicyEvaluationError
+
+    # Invalid type for 'timing'
+    json_str_invalid_type = """{
+        "intervention": {
+            "name": "test",
+            "timing": 123,
+            "comparator": "control"
+        },
+        "causal_model": {
+            "name": "cm",
+            "treatment_variable": "t",
+            "outcome_variable": "o",
+            "confounders": ["c"]
+        }
+    }"""
+
+    import pytest
+
+    with pytest.raises(PolicyEvaluationError) as excinfo:
+        CausalModel.from_json(json_str_invalid_type)
+    assert "Data validation error" in str(excinfo.value)


### PR DESCRIPTION
🎯 **What:** Applied `ruff format` to `src/innovate/causal/policy.py` to fix formatting issues on PR #318.
💡 **Why:** To make the PR compliant with the project's formatting standards, specifically resolving double-space requirements before inline type ignore comments.
✅ **Verification:** Ran `ruff format --check` and `ruff check`, and executed `pytest tests/unit/test_causal_policy_*.py` to ensure unit tests still pass. Restored `pr_description.md` which was inadvertently deleted in a prior commit.
✨ **Result:** Cleanly formatted file with all security checks intact.

---
*PR created automatically by Jules for task [2161231048881529273](https://jules.google.com/task/2161231048881529273) started by @edithatogo*