### PR TITLE
🔒 [security hardening] Hardened GitHub Actions workflows based on zizmor/actionlint

### DIFF
--- a/.github/workflows/binding-conformance.yml
+++ b/.github/workflows/binding-conformance.yml
@@ -18,10 +18,12 @@ jobs:
   shared-contract:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@6026fb2ad3aa556d78b517cf65c8c1f832075860 # v5
+        with:
+          persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           enable-cache: true
 
@@ -40,7 +42,7 @@ jobs:
             -q
 
       - name: Upload binding conformance evidence
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: binding-conformance-evidence
           path: |

--- a/.github/workflows/bindings-publish.yml
+++ b/.github/workflows/bindings-publish.yml
@@ -12,19 +12,21 @@ on:
         type: choice
         options: ["true", "false"]
 
-permissions:
-  contents: write
-  id-token: write
 
 jobs:
   npm-typescript:
+    permissions:
+      id-token: write
+      contents: read
     runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: bindings/typescript
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@6026fb2ad3aa556d78b517cf65c8c1f832075860 # v5
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: "26"
           registry-url: https://registry.npmjs.org
@@ -48,8 +50,10 @@ jobs:
       run:
         working-directory: bindings/rust
     steps:
-      - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@6026fb2ad3aa556d78b517cf65c8c1f832075860 # v5
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
         with:
           components: rustfmt, clippy
       - run: cargo fmt --check
@@ -67,17 +71,19 @@ jobs:
         if: ${{ github.event_name == 'release' || inputs.dry_run == 'false' }}
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: cargo publish
+        run: cargo publish --token "$CARGO_REGISTRY_TOKEN"
 
   r-package:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: r-lib/actions/setup-r@v2
+      - uses: actions/checkout@6026fb2ad3aa556d78b517cf65c8c1f832075860 # v5
+        with:
+          persist-credentials: false
+      - uses: r-lib/actions/setup-r@1b6976fa8cb4659b87612c6aeb55a73e5f2a13cc # v2
       - name: Set up TinyTeX for R manual PDF
-        uses: r-lib/actions/setup-tinytex@v2
+        uses: r-lib/actions/setup-tinytex@9c1f618a803732c525f0a205d5be5a2abec5efd5 # v2
       - name: Set up Pandoc for R vignettes
-        uses: r-lib/actions/setup-pandoc@v2
+        uses: r-lib/actions/setup-pandoc@d1616ba6ec89db490a6e036e6a10de4e2e283c74 # v2
       - run: |
           Rscript -e 'repos <- Sys.getenv("RSPM", "https://cloud.r-project.org"); packages <- c("jsonlite", "knitr", "rmarkdown"); install.packages(packages, repos = repos); missing <- packages[!vapply(packages, requireNamespace, logical(1), quietly = TRUE)]; if (length(missing)) stop("Missing R packages: ", paste(missing, collapse = ", "))'
       - name: Read R package metadata
@@ -86,41 +92,51 @@ jobs:
           Rscript -e 'd <- read.dcf("bindings/r/DESCRIPTION")[1, ]; cat("package=", d[["Package"]], "\nversion=", d[["Version"]], "\n", sep = "")' >> "$GITHUB_OUTPUT"
       - run: R CMD build bindings/r
       - name: Build R manual PDF
+        env:
+          STEPS_R_METADATA_OUTPUTS_PACKAGE: ${{ steps.r_metadata.outputs.package }}
+          STEPS_R_METADATA_OUTPUTS_VERSION: ${{ steps.r_metadata.outputs.version }}
         run: |
           mkdir -p artifacts/r-manual
           R CMD Rd2pdf --no-preview \
-            --output="artifacts/r-manual/${{ steps.r_metadata.outputs.package }}_${{ steps.r_metadata.outputs.version }}_manual.pdf" \
+            --output="artifacts/r-manual/${STEPS_R_METADATA_OUTPUTS_PACKAGE}_${STEPS_R_METADATA_OUTPUTS_VERSION}_manual.pdf" \
             bindings/r
-          test -s "artifacts/r-manual/${{ steps.r_metadata.outputs.package }}_${{ steps.r_metadata.outputs.version }}_manual.pdf"
+          test -s "artifacts/r-manual/${STEPS_R_METADATA_OUTPUTS_PACKAGE}_${STEPS_R_METADATA_OUTPUTS_VERSION}_manual.pdf"
       - run: R CMD check --as-cran --no-manual innovate.R_*.tar.gz
       - name: Upload R package artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: r-package-source-${{ steps.r_metadata.outputs.package }}-${{ steps.r_metadata.outputs.version }}
           path: innovate.R_*.tar.gz
       - name: Upload R manual PDF artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: r-manual-${{ steps.r_metadata.outputs.package }}-${{ steps.r_metadata.outputs.version }}
           path: artifacts/r-manual/${{ steps.r_metadata.outputs.package }}_${{ steps.r_metadata.outputs.version }}_manual.pdf
       - name: Validate R release artifacts
+        env:
+          STEPS_R_METADATA_OUTPUTS_VERSION: ${{ steps.r_metadata.outputs.version }}
+          STEPS_R_METADATA_OUTPUTS_PACKAGE: ${{ steps.r_metadata.outputs.package }}
         run: |
-          test -s "innovate.R_${{ steps.r_metadata.outputs.version }}.tar.gz"
-          test -s "artifacts/r-manual/${{ steps.r_metadata.outputs.package }}_${{ steps.r_metadata.outputs.version }}_manual.pdf"
+          test -s "innovate.R_${STEPS_R_METADATA_OUTPUTS_VERSION}.tar.gz"
+          test -s "artifacts/r-manual/${STEPS_R_METADATA_OUTPUTS_PACKAGE}_${STEPS_R_METADATA_OUTPUTS_VERSION}_manual.pdf"
       - name: R-universe and CRAN publication gate
         run: |
           echo "R-universe publication is driven by the configured universe registry."
           echo "CRAN submission remains a manual maintainer release step after R CMD check --as-cran and manual PDF generation pass."
 
   julia-package:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@6026fb2ad3aa556d78b517cf65c8c1f832075860 # v5
+        with:
+          persist-credentials: false
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
       - name: Set up Python
         run: uv python install 3.14
-      - uses: julia-actions/setup-julia@v2
+      - uses: julia-actions/setup-julia@4c0cb0fce8556fdb04a90347310e5db8b1f98fb9 # v2
         with:
           version: "1.12"
       - run: julia --project=bindings/julia -e 'using Pkg; Pkg.instantiate(); Pkg.test()'
@@ -147,15 +163,20 @@ jobs:
           echo "A dedicated Innovate.jl repository may still be needed for Julia General AutoMerge; otherwise expect manual review."
 
   go-module:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: bindings/go
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@6026fb2ad3aa556d78b517cf65c8c1f832075860 # v5
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version-file: bindings/go/go.mod
+          cache: false
       - run: go test ./...
       - run: go list -m
       - name: Validate Go module release tag pattern
@@ -200,13 +221,17 @@ jobs:
           exit 1
 
   nuget-csharp:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: astral-sh/setup-uv@v8.1.0
+      - uses: actions/checkout@6026fb2ad3aa556d78b517cf65c8c1f832075860 # v5
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
       - run: uv python install 3.14
       - run: uv sync
-      - uses: actions/setup-dotnet@v5
+      - uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
         with:
           dotnet-version: |
             10.0.x

--- a/.github/workflows/ci-gate-monitor.yml
+++ b/.github/workflows/ci-gate-monitor.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check for existing failure issue
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const { owner, repo } = context.repo;
@@ -57,8 +57,8 @@ jobs:
             }
 
       - name: Post PR comment if applicable
-        if: ${{ github.event.workflow_run.pull_requests[0] }}
-        uses: actions/github-script@v7
+        if: ${{ github.event.workflow_run.pull_requests != '' }}
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const { owner, repo } = context.repo;

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,12 @@ jobs:
   prose-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@6026fb2ad3aa556d78b517cf65c8c1f832075860 # v5
+        with:
+          persist-credentials: false
 
       - name: Run Vale
-        uses: vale-cli/vale-action@v2.1.1
+        uses: vale-cli/vale-action@d89dee975228ae261d22c15adcd03578634d429c # v2.1.1
         with:
           files: README.md,docs,conductor,specs
           separator: ","
@@ -50,10 +52,12 @@ jobs:
               --ignore=tests/unit/test_specific_modules_coverage.py
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@6026fb2ad3aa556d78b517cf65c8c1f832075860 # v5
+        with:
+          persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           enable-cache: true
 
@@ -92,7 +96,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: matrix.python-version == '3.14'
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@04b047e8bb82a0c002c8312c1c880fbc6a999d45 # v5
         with:
           files: ./coverage.xml
           fail_ci_if_error: false
@@ -101,10 +105,12 @@ jobs:
   optional-backend-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@6026fb2ad3aa556d78b517cf65c8c1f832075860 # v5
+        with:
+          persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           enable-cache: true
 
@@ -136,10 +142,12 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@6026fb2ad3aa556d78b517cf65c8c1f832075860 # v5
+        with:
+          persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
       - name: Set up Python
         run: uv python install 3.14
@@ -167,10 +175,12 @@ jobs:
   package:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@6026fb2ad3aa556d78b517cf65c8c1f832075860 # v5
+        with:
+          persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
       - name: Set up Python
         run: uv python install 3.14
@@ -200,22 +210,24 @@ jobs:
       run:
         working-directory: docs/astro-site
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@6026fb2ad3aa556d78b517cf65c8c1f832075860 # v5
+        with:
+          persist-credentials: false
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
         with:
           version: 9.15.9
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "22"
           cache: "pnpm"
           cache-dependency-path: docs/astro-site/pnpm-lock.yaml
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.14"
 
@@ -235,16 +247,18 @@ jobs:
       matrix:
         rust-version: ["1.85.0", "stable"]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@6026fb2ad3aa556d78b517cf65c8c1f832075860 # v5
+        with:
+          persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
       - name: Set up Python
         run: uv python install 3.14
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
         with:
           toolchain: ${{ matrix.rust-version }}
           components: rustfmt, clippy
@@ -274,16 +288,18 @@ jobs:
   rust-benchmarks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@6026fb2ad3aa556d78b517cf65c8c1f832075860 # v5
+        with:
+          persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
       - name: Set up Python
         run: uv python install 3.14
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
 
       - name: Validate Rust migration inventory
         working-directory: bindings/rust
@@ -336,16 +352,18 @@ jobs:
       matrix:
         node-version: ["26"]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@6026fb2ad3aa556d78b517cf65c8c1f832075860 # v5
+        with:
+          persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
       - name: Set up Python
         run: uv python install 3.14
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm
@@ -378,16 +396,18 @@ jobs:
       matrix:
         go-version: ["1.25.x", "1.26.x"]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@6026fb2ad3aa556d78b517cf65c8c1f832075860 # v5
+        with:
+          persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
       - name: Set up Python
         run: uv python install 3.14
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version: ${{ matrix.go-version }}
 
@@ -411,16 +431,18 @@ jobs:
       matrix:
         julia-version: ["1.12", "nightly"]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@6026fb2ad3aa556d78b517cf65c8c1f832075860 # v5
+        with:
+          persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
       - name: Set up Python
         run: uv python install 3.14
 
       - name: Set up Julia
-        uses: julia-actions/setup-julia@v2
+        uses: julia-actions/setup-julia@4c0cb0fce8556fdb04a90347310e5db8b1f98fb9 # v2
         with:
           version: ${{ matrix.julia-version }}
 
@@ -446,22 +468,24 @@ jobs:
   r-bindings:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@6026fb2ad3aa556d78b517cf65c8c1f832075860 # v5
+        with:
+          persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
       - name: Set up Python
         run: uv python install 3.14
 
       - name: Set up R
-        uses: r-lib/actions/setup-r@v2
+        uses: r-lib/actions/setup-r@1b6976fa8cb4659b87612c6aeb55a73e5f2a13cc # v2
 
       - name: Set up TinyTeX for R manual PDF
-        uses: r-lib/actions/setup-tinytex@v2
+        uses: r-lib/actions/setup-tinytex@9c1f618a803732c525f0a205d5be5a2abec5efd5 # v2
 
       - name: Set up Pandoc for R vignettes
-        uses: r-lib/actions/setup-pandoc@v2
+        uses: r-lib/actions/setup-pandoc@d1616ba6ec89db490a6e036e6a10de4e2e283c74 # v2
 
       - name: Install R binding dependencies
         run: |
@@ -484,12 +508,15 @@ jobs:
         run: |
           mkdir -p artifacts/r-manual
           R CMD Rd2pdf --no-preview \
-            --output="artifacts/r-manual/${{ steps.r_metadata.outputs.package }}_${{ steps.r_metadata.outputs.version }}_manual.pdf" \
+            --output="artifacts/r-manual/${STEPS_R_METADATA_OUTPUTS_PACKAGE}_${STEPS_R_METADATA_OUTPUTS_VERSION}_manual.pdf" \
             bindings/r
-          test -s "artifacts/r-manual/${{ steps.r_metadata.outputs.package }}_${{ steps.r_metadata.outputs.version }}_manual.pdf"
+          test -s "artifacts/r-manual/${STEPS_R_METADATA_OUTPUTS_PACKAGE}_${STEPS_R_METADATA_OUTPUTS_VERSION}_manual.pdf"
+        env:
+          STEPS_R_METADATA_OUTPUTS_PACKAGE: ${{ steps.r_metadata.outputs.package }}
+          STEPS_R_METADATA_OUTPUTS_VERSION: ${{ steps.r_metadata.outputs.version }}
 
       - name: Upload R manual PDF artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: r-manual-${{ steps.r_metadata.outputs.package }}-${{ steps.r_metadata.outputs.version }}
           path: artifacts/r-manual/${{ steps.r_metadata.outputs.package }}_${{ steps.r_metadata.outputs.version }}_manual.pdf
@@ -508,10 +535,12 @@ jobs:
           - dotnet-version: "11.0.x"
             target-framework: "net11.0"
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@6026fb2ad3aa556d78b517cf65c8c1f832075860 # v5
+        with:
+          persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
       - name: Set up Python
         run: uv python install 3.14
@@ -520,7 +549,7 @@ jobs:
         run: uv sync
 
       - name: Set up .NET ${{ matrix.dotnet-version }}
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
         with:
           dotnet-version: ${{ matrix.dotnet-version }}
 
@@ -539,10 +568,12 @@ jobs:
   type-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@6026fb2ad3aa556d78b517cf65c8c1f832075860 # v5
+        with:
+          persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
       - name: Set up Python
         run: uv python install 3.14
@@ -568,10 +599,12 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'workflow_dispatch'
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@6026fb2ad3aa556d78b517cf65c8c1f832075860 # v5
+        with:
+          persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
       - name: Set up Python
         run: uv python install 3.14
@@ -588,10 +621,12 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'workflow_dispatch'
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@6026fb2ad3aa556d78b517cf65c8c1f832075860 # v5
+        with:
+          persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
       - name: Set up Python
         run: uv python install 3.14
@@ -608,10 +643,12 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'workflow_dispatch'
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@6026fb2ad3aa556d78b517cf65c8c1f832075860 # v5
+        with:
+          persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
       - name: Set up Python
         run: uv python install 3.14
@@ -632,10 +669,12 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'workflow_dispatch'
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@6026fb2ad3aa556d78b517cf65c8c1f832075860 # v5
+        with:
+          persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
       - name: Set up Python
         run: uv python install 3.14
@@ -653,7 +692,7 @@ jobs:
         run: uv run pytest --benchmark-only --benchmark-json=benchmark.json
 
       - name: Upload benchmark results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: benchmark-results
           path: benchmark.json
@@ -665,10 +704,12 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'schedule'
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@6026fb2ad3aa556d78b517cf65c8c1f832075860 # v5
+        with:
+          persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
       - name: Set up Python
         run: uv python install 3.14

--- a/.github/workflows/conda-publish.yml
+++ b/.github/workflows/conda-publish.yml
@@ -10,13 +10,16 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@6026fb2ad3aa556d78b517cf65c8c1f832075860 # v5
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up conda environment
-        uses: conda-incubator/setup-miniconda@v3
+        uses: conda-incubator/setup-miniconda@fc2d68f6413eb2d87b895e92f8584b5b94a10167 # v3
         with:
           auto-update-conda: true
           python-version: "3.14"

--- a/.github/workflows/dependency-dashboard.yml
+++ b/.github/workflows/dependency-dashboard.yml
@@ -12,38 +12,40 @@ jobs:
   dependency-dashboard:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@6026fb2ad3aa556d78b517cf65c8c1f832075860 # v5
+        with:
+          persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
       - name: Set up Python
         run: uv python install 3.14
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: "26"
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
         with:
           version: 9.15.9
           run_install: false
 
       - name: Set up Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
 
       - name: Set up R
-        uses: r-lib/actions/setup-r@v2
+        uses: r-lib/actions/setup-r@1b6976fa8cb4659b87612c6aeb55a73e5f2a13cc # v2
 
       - name: Set up Julia
-        uses: julia-actions/setup-julia@v2
+        uses: julia-actions/setup-julia@4c0cb0fce8556fdb04a90347310e5db8b1f98fb9 # v2
         with:
           version: "1.12"
 
       - name: Set up .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
         with:
           dotnet-version: |
             10.0.x
@@ -58,7 +60,7 @@ jobs:
         run: uv run python scripts/dependency_dashboard.py --output-dir dependency-dashboard
 
       - name: Upload dependency dashboard
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: dependency-dashboard
           path: dependency-dashboard

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,22 +26,24 @@ jobs:
         working-directory: docs/astro-site
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@6026fb2ad3aa556d78b517cf65c8c1f832075860 # v5
+        with:
+          persist-credentials: false
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
         with:
           version: 9.15.9
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '22'
           cache: 'pnpm'
           cache-dependency-path: docs/astro-site/pnpm-lock.yaml
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.14'
 
@@ -60,7 +62,7 @@ jobs:
       - name: Verify production documentation contract
         run: python ../../scripts/verify_production_docs.py --json
 
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@a2cb6db149c4fbf5ee2c130ccb00b0e515cebfb3 # v3
         with:
           path: docs/astro-site/dist/
 
@@ -78,4 +80,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -13,12 +13,17 @@ jobs:
       url: https://pypi.org/p/innovate
     permissions:
       id-token: write
+      contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@6026fb2ad3aa556d78b517cf65c8c1f832075860 # v5
+        with:
+          persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: false
 
       - name: Set up Python
         run: uv python install 3.14
@@ -33,4 +38,4 @@ jobs:
         run: uv run twine check dist/*
 
       - name: Publish package to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@716c507c5a083a216fcb67ba395f190a6ea5b106 # release/v1

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -10,8 +10,11 @@ on:
 jobs:
   update_release_draft:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
     steps:
-      - uses: release-drafter/release-drafter@v6
+      - uses: release-drafter/release-drafter@494baec14fb717efabdd8f3a3f5b7cb347bd78bb # v6
         with:
           config-name: release-drafter.yml
         env:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,7 +12,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@512809dcf9829afec14e6677ccddce3d9ba6cdfe # v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           release-type: python

--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -20,10 +20,12 @@ jobs:
   readiness-report:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@6026fb2ad3aa556d78b517cf65c8c1f832075860 # v5
+        with:
+          persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           enable-cache: true
 
@@ -43,7 +45,7 @@ jobs:
         run: uv run nox -s release_readiness
 
       - name: Upload release-readiness-report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: release-readiness-report
           path: |
@@ -55,7 +57,9 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@6026fb2ad3aa556d78b517cf65c8c1f832075860 # v5
+        with:
+          persist-credentials: false
 
       - name: Document scheduled or manual release lane
         run: |
@@ -64,7 +68,7 @@ jobs:
             'Mutation sampling, package dry-runs, compatibility sweeps, and external audit refreshes stay out of fast PR checks.'
 
       - name: Upload release lane note
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: release-lane-checks
           path: .github/workflows/release-readiness.yml

--- a/.github/workflows/tagbot.yml
+++ b/.github/workflows/tagbot.yml
@@ -14,6 +14,6 @@ jobs:
   tagbot:
     runs-on: ubuntu-latest
     steps:
-      - uses: JuliaRegistries/TagBot@v1
+      - uses: JuliaRegistries/TagBot@10f545465e903a74de5b26ad005a769532fcbc22 # v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/testpypi-publish.yml
+++ b/.github/workflows/testpypi-publish.yml
@@ -12,13 +12,18 @@ jobs:
       name: testpypi
       url: https://test.pypi.org/p/innovate
     permissions:
-      id-token: write # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
+      contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@6026fb2ad3aa556d78b517cf65c8c1f832075860 # v5
+        with:
+          persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: false
 
       - name: Set up Python
         run: uv python install 3.14
@@ -33,8 +38,6 @@ jobs:
         run: uv run twine check dist/*
 
       - name: Publish package to TestPyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@716c507c5a083a216fcb67ba395f190a6ea5b106 # release/v1
         with:
-          user: __token__
-          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
           repository-url: https://test.pypi.org/legacy/


### PR DESCRIPTION
🎯 **What:**
- Pinned all third-party GitHub Actions to immutable commit SHAs.
- Enforced least-privilege job-level permissions and removed overly broad workflow-level write permissions.
- Added `persist-credentials: false` to all `actions/checkout` steps to prevent accidental token leakage.
- Transitioned PyPI/TestPyPI publishing to Trusted Publishing (OIDC) by utilizing `id-token: write` and removing manual API tokens.
- Mitigated template injection risks in R-package validation by passing GitHub contexts to `env:` blocks.
- Disabled dependency caching in publish-oriented workflows to prevent cache-poisoning attacks.
- Safely addressed dangerous triggers (`workflow_run`) by ensuring array bounds are appropriately checked via `actionlint`.

⚠️ **Risk:**
- Previous configurations were vulnerable to supply-chain attacks via mutable action tags, credential persistence in checkout directories, overly permissive tokens, and potential template injections.

🛡️ **Solution:**
- Adopted strict guidelines from OpenSSF Scorecard, `actionlint`, and `zizmor` to implement immutable dependencies and least-privilege execution environments across the entire `.github/workflows` directory.

---
*PR created automatically by Jules for task [2618424086566180982](https://jules.google.com/task/2618424086566180982) started by @edithatogo*