### PR TITLE
🧪 [test] verify predict output during recovery test

### DIFF
--- a/tests/unit/test_recovery.py
+++ b/tests/unit/test_recovery.py
@@ -67,20 +67,20 @@ def test_model_recovery_after_error():
     model.params_ = {}
 
     # Attempt to call predict (should fail)
-    predict_failed = False
-    try:
+    with pytest.raises(RuntimeError, match="Model has not been fitted yet"):
         model.predict([1, 2, 3])
-    except RuntimeError:
-        predict_failed = True
-
-    assert predict_failed, "Expected predict to fail with unfitted model"
 
     # Now fix the model by setting valid parameters
     model.params_ = {"p": 0.03, "q": 0.38, "m": 1000}
 
     # The model should now work properly
-    # We won't call predict since that might trigger ODE solver
-    # Instead, verify the parameters are properly set
+    # Actually call predict to verify recovery
+    predictions = model.predict([1, 2, 3])
+
+    assert predictions is not None
+    assert len(predictions) == 3
+
+    # Also verify the parameters are properly set
     assert model.params_["p"] == 0.03
     assert model.params_["q"] == 0.38
     assert model.params_["m"] == 1000


### PR DESCRIPTION
🎯 **What:**\nReplaced the manual try/except block with `with pytest.raises(RuntimeError)` in `test_model_recovery_after_error` and verified the model's recovery by explicitly calling `model.predict()` and checking its output, rather than just asserting the internal parameters.\n\n📊 **Coverage:**\n`tests/unit/test_recovery.py` - Specifically testing prediction recovery after error state.\n\n✨ **Result:**\nThe test is now more idiomatic (using `pytest.raises`) and properly validates that the model actually works (can produce predictions) after recovering from an error condition.

---
*PR created automatically by Jules for task [9446723744007096062](https://jules.google.com/task/9446723744007096062) started by @edithatogo*