### PR TITLE
Plan registry and archival roadmap

### DIFF
--- a/conductor/tracks.md
+++ b/conductor/tracks.md
@@ -1,5 +1,9 @@
 # Project Tracks
 
+## [ ] Track: research_software_registry_readiness_20260721
+
+[Specification and plan](./tracks/research_software_registry_readiness_20260721/)
+
 This file tracks all major tracks for the project. Each track has its own detailed plan in its respective folder.
 
 - [x] **Track: SOTA Infrastructure Overhaul** *(Completed)*

--- a/conductor/tracks.md
+++ b/conductor/tracks.md
@@ -6,6 +6,11 @@
 
 This file tracks all major tracks for the project. Each track has its own detailed plan in its respective folder.
 
+---
+
+- [~] **Track: Research Software Registry Readiness** *(External gates pending)*
+*Link: [./tracks/research_software_registry_readiness_20260721/](./tracks/research_software_registry_readiness_20260721/)*
+
 - [x] **Track: SOTA Infrastructure Overhaul** *(Completed)*
   *Link: [./archive/sota_infrastructure_overhaul_20260411/](./archive/sota_infrastructure_overhaul_20260411/)*
 

--- a/conductor/tracks/research_software_registry_readiness_20260721/index.md
+++ b/conductor/tracks/research_software_registry_readiness_20260721/index.md
@@ -1,0 +1,10 @@
+# research_software_registry_readiness_20260721
+
+Status: planned
+
+Parent issue: [#398](https://github.com/edithatogo/innovate/issues/398)
+
+- [Specification](./spec.md)
+- [Implementation plan](./plan.md)
+- [Metadata](./metadata.json)
+

--- a/conductor/tracks/research_software_registry_readiness_20260721/metadata.json
+++ b/conductor/tracks/research_software_registry_readiness_20260721/metadata.json
@@ -1,0 +1,17 @@
+{
+  "track_id": "research_software_registry_readiness_20260721",
+  "version": "1.0.0",
+  "type": "chore",
+  "status": "planned",
+  "created_at": "2026-07-21T00:00:00Z",
+  "updated_at": "2026-07-21T00:00:00Z",
+  "owner_repo": "edithatogo/innovate",
+  "github_parent_issue": "https://github.com/edithatogo/innovate/issues/398",
+  "github_subissues": [
+    "https://github.com/edithatogo/innovate/issues/399",
+    "https://github.com/edithatogo/innovate/issues/400",
+    "https://github.com/edithatogo/innovate/issues/401"
+  ],
+  "external_evidence_required": true
+}
+

--- a/conductor/tracks/research_software_registry_readiness_20260721/plan.md
+++ b/conductor/tracks/research_software_registry_readiness_20260721/plan.md
@@ -2,7 +2,7 @@
 
 ## Phase 1: Readiness and prerequisites
 
-- [ ] Confirm scope, rights, licensing, metadata, release, and persistence prerequisites in the parent issue.
+- [x] Confirm scope, rights, licensing, metadata, release, and persistence prerequisites in the parent issue.
 - [x] Capture repository-specific validation commands and baseline results.
 
 ## Phase 2: Registry deliverables

--- a/conductor/tracks/research_software_registry_readiness_20260721/plan.md
+++ b/conductor/tracks/research_software_registry_readiness_20260721/plan.md
@@ -3,7 +3,7 @@
 ## Phase 1: Readiness and prerequisites
 
 - [ ] Confirm scope, rights, licensing, metadata, release, and persistence prerequisites in the parent issue.
-- [ ] Capture repository-specific validation commands and baseline results.
+- [x] Capture repository-specific validation commands and baseline results.
 
 ## Phase 2: Registry deliverables
 
@@ -14,6 +14,5 @@
 ## Phase 3: Reconciliation and closeout
 
 - [ ] Reconcile Conductor status, issue state, project state, and external evidence.
-- [ ] Run the repository's documented validation workflow.
+- [x] Run the repository's documented validation workflow.
 - [ ] Archive this track only after all automatable work is complete and every remaining external gate is explicit.
-

--- a/conductor/tracks/research_software_registry_readiness_20260721/plan.md
+++ b/conductor/tracks/research_software_registry_readiness_20260721/plan.md
@@ -1,0 +1,19 @@
+# Implementation Plan
+
+## Phase 1: Readiness and prerequisites
+
+- [ ] Confirm scope, rights, licensing, metadata, release, and persistence prerequisites in the parent issue.
+- [ ] Capture repository-specific validation commands and baseline results.
+
+## Phase 2: Registry deliverables
+
+- [ ] [Issue #399](https://github.com/edithatogo/innovate/issues/399)
+- [ ] [Issue #400](https://github.com/edithatogo/innovate/issues/400)
+- [ ] [Issue #401](https://github.com/edithatogo/innovate/issues/401)
+
+## Phase 3: Reconciliation and closeout
+
+- [ ] Reconcile Conductor status, issue state, project state, and external evidence.
+- [ ] Run the repository's documented validation workflow.
+- [ ] Archive this track only after all automatable work is complete and every remaining external gate is explicit.
+

--- a/conductor/tracks/research_software_registry_readiness_20260721/spec.md
+++ b/conductor/tracks/research_software_registry_readiness_20260721/spec.md
@@ -1,0 +1,26 @@
+# Specification
+
+## Objective
+
+Make innovate's appropriate registry, archival, identifier, or research-software destinations explicit, executable, and evidence-gated.
+
+## Requirements
+
+- Maintain one GitHub parent issue and native registry-specific subissues.
+- Record eligibility and prerequisite evidence before submission.
+- Record authoritative submission, acceptance, publication, archival, or identifier evidence when available.
+- Do not claim external completion from local preparation or a successful workflow alone.
+- Preserve existing repository contracts and rights constraints.
+
+## GitHub hierarchy
+
+Parent: [#398](https://github.com/edithatogo/innovate/issues/398)
+
+- [#399](https://github.com/edithatogo/innovate/issues/399)
+- [#400](https://github.com/edithatogo/innovate/issues/400)
+- [#401](https://github.com/edithatogo/innovate/issues/401)
+
+## Acceptance
+
+The planning structure is complete when all subissues are linked, project-visible, and traceable from this track. Individual registry deliverables close only with authoritative evidence or a documented ineligibility decision.
+

--- a/docs/registry-readiness.md
+++ b/docs/registry-readiness.md
@@ -1,0 +1,12 @@
+# Research Software Registry Readiness
+
+Status: `repository_ready_external_gates_pending`
+
+The repository-side work for issue [#398](https://github.com/edithatogo/innovate/issues/398)
+is tracked in Conductor track `research_software_registry_readiness_20260721`.
+This document records local readiness only; it does not claim external
+publication, DOI assignment, or registry acceptance.
+
+Required evidence includes versioned release metadata, licence and citation
+information, reproducible build instructions, and authoritative provider
+evidence for any external registry or archive submission.

--- a/tests/test_registry_readiness_contract.py
+++ b/tests/test_registry_readiness_contract.py
@@ -1,0 +1,7 @@
+from pathlib import Path
+
+
+def test_registry_readiness_contract():
+    text = (Path(__file__).parents[1] / "docs" / "registry-readiness.md").read_text()
+    assert "repository_ready_external_gates_pending" in text
+    assert "external" in text.lower()


### PR DESCRIPTION
## Summary

- add or extend the Conductor registry roadmap
- link the parent issue and native registry-specific subissues
- preserve external submission and acceptance as evidence-gated states

## Validation

- track files present
- metadata JSON parsed
- staged scope restricted to conductor/