### PR TITLE
🧪 [test improvement] Fix recovery tests

### DIFF
--- a/tests/unit/test_recovery.py
+++ b/tests/unit/test_recovery.py
@@ -67,23 +67,16 @@ def test_model_recovery_after_error():
     model.params_ = {}
 
     # Attempt to call predict (should fail)
-    predict_failed = False
-    try:
+    with pytest.raises(RuntimeError, match="Model has not been fitted yet"):
         model.predict([1, 2, 3])
-    except RuntimeError:
-        predict_failed = True
-
-    assert predict_failed, "Expected predict to fail with unfitted model"
 
     # Now fix the model by setting valid parameters
     model.params_ = {"p": 0.03, "q": 0.38, "m": 1000}
 
     # The model should now work properly
-    # We won't call predict since that might trigger ODE solver
-    # Instead, verify the parameters are properly set
-    assert model.params_["p"] == 0.03
-    assert model.params_["q"] == 0.38
-    assert model.params_["m"] == 1000
+    # Perform a functional check to verify recovery
+    predictions = model.predict([1, 2, 3])
+    assert len(predictions) == 3
 
 
 def test_parameter_validation_recovery():
@@ -127,7 +120,7 @@ def test_model_state_preservation():
 
     # Save initial state
     initial_covariates = model.covariates
-    initial_params = model.params_
+    _ = model.params_
 
     # Set parameters
     model.params_ = {"p": 0.03, "q": 0.38, "m": 1000}
@@ -180,18 +173,17 @@ def test_consistent_state_after_exception():
 
     # Attempt an operation that will fail (without fitted params)
     model.params_ = {}
-    predict_failed = False
-    try:
+    with pytest.raises(RuntimeError, match="Model has not been fitted yet"):
         model.predict([1, 2, 3])
-    except RuntimeError:
-        predict_failed = True
-
-    assert predict_failed
 
     # Restore valid parameters
     model.params_ = initial_params
 
-    # Verify model is back to a valid state
+    # Verify model is back to a valid state functionally
+    predictions = model.predict([1, 2, 3])
+    assert len(predictions) == 3
+
+    # Also verify attributes
     for key, expected_value in initial_params.items():
         assert model.params_[key] == expected_value
 


### PR DESCRIPTION
🎯 **What:**
- Replaced manual try-except blocks with `pytest.raises`.
- Added functional verification (calling `predict()`) instead of purely attribute-based assertion for post-recovery checks.

📊 **Coverage:**
- Addressed `test_model_recovery_after_error` and `test_consistent_state_after_exception` in `tests/unit/test_recovery.py`.

✨ **Result:**
- Improved testing reliability. Tests assert that prediction succeeds after recovery.

---
*PR created automatically by Jules for task [17874891790643982371](https://jules.google.com/task/17874891790643982371) started by @edithatogo*