### PR TITLE
🔒 [security fix] Suppress false positive security warning on PRNG

### DIFF
--- a/src/innovate/abm/model.py
+++ b/src/innovate/abm/model.py
@@ -17,8 +17,8 @@ class InnovationModel(Model):
         for i in range(self.num_agents):
             agent = InnovationAgent(i, self)
             # Add the agent to a random grid cell
-            x = self.random.randrange(self.grid.width)
-            y = self.random.randrange(self.grid.height)
+            x = self.random.randrange(self.grid.width)  # nosec
+            y = self.random.randrange(self.grid.height)  # nosec
             self.grid.place_agent(agent, (x, y))
 
     def step(self):


### PR DESCRIPTION
🎯 **What:** Suppressed Bandit/Ruff S311 warning for `random.randrange` in `src/innovate/abm/model.py`.
⚠️ **Risk:** The code was flagged for using an insecure PRNG.
🛡️ **Solution:** Used `# nosec` comment to suppress the false positive warning. The use of `random.randrange` is intentional and secure in this context, as Mesa relies on a seeded PRNG (`self.random`) to guarantee reproducible ABM simulations. Replacing it with a CSPRNG like `secrets` would break simulation reproducibility.

---
*PR created automatically by Jules for task [9437975986694939150](https://jules.google.com/task/9437975986694939150) started by @edithatogo*