### PR TITLE
🔒 [security fix] Add input size validation to JSON deserialization

### DIFF
--- a/src/innovate/causal/policy.py
+++ b/src/innovate/causal/policy.py
@@ -186,6 +186,13 @@ class CausalModel:
     @classmethod
     def from_json(cls, json_str: str) -> CausalModel:
         """Load causal model from JSON."""
+        if not isinstance(json_str, str):
+            raise PolicyEvaluationError("Input must be a string")
+
+        # Limit input size to prevent DoS via excessively large JSON (1MB max)
+        if len(json_str) > 1_048_576:
+            raise PolicyEvaluationError("Input JSON string exceeds maximum allowed length of 1MB")
+
         try:
             data = json.loads(json_str)
         except json.JSONDecodeError as e:

--- a/tests/unit/test_causal_policy_security.py
+++ b/tests/unit/test_causal_policy_security.py
@@ -124,3 +124,15 @@ def test_causal_model_from_json_missing_keys_rejected():
     # Missing "name" in intervention contract
     with pytest.raises(PolicyEvaluationError, match="Data validation error"):
         CausalModel.from_json(invalid_json)
+
+
+def test_causal_model_from_json_input_not_string():
+    with pytest.raises(PolicyEvaluationError, match="Input must be a string"):
+        CausalModel.from_json({"key": "value"})  # type: ignore
+
+
+def test_causal_model_from_json_input_too_large():
+    # 1MB is 1_048_576 bytes. We will create a string just slightly larger.
+    large_json = '{"a": "' + "x" * 1_048_576 + '"}'
+    with pytest.raises(PolicyEvaluationError, match="Input JSON string exceeds maximum allowed length of 1MB"):
+        CausalModel.from_json(large_json)


### PR DESCRIPTION
🎯 **What:** Added a maximum string length limit and string type validation to `CausalModel.from_json()`.
⚠️ **Risk:** The previous implementation called `json.loads()` directly on unbounded input strings, exposing the system to Denial of Service (DoS) attacks via memory exhaustion or high CPU usage from excessively large JSON payloads.
🛡️ **Solution:** Enforced a strict 1MB size limit and runtime type checking on the input `json_str` before parsing. This prevents malicious payloads from consuming excessive resources.

---
*PR created automatically by Jules for task [6911663055635180338](https://jules.google.com/task/6911663055635180338) started by @edithatogo*