### PR TITLE
🔒 [security fix] Suppress false positive security warning on PRNG in ABM models

### DIFF
--- a/src/innovate/abm/competitive_diffusion.py
+++ b/src/innovate/abm/competitive_diffusion.py
@@ -58,13 +58,13 @@ class CompetitiveDiffusionModel(Model):
                 model=self,
                 num_innovations=num_innovations,
             )
-            x = self.random.randrange(self.grid.width)
-            y = self.random.randrange(self.grid.height)
+            x = self.random.randrange(self.grid.width)  # nosec
+            y = self.random.randrange(self.grid.height)  # nosec
             self.grid.place_agent(agent, (x, y))
 
         # Seed initial adopters for each innovation
         for i in range(self.num_innovations):
-            agent = self.random.choice(list(self.agents))
+            agent = self.random.choice(list(self.agents))  # nosec
             agent.adopted_innovation = i
 
         # Data collector - track count of adopters for each innovation

--- a/src/innovate/abm/disruptive_innovation.py
+++ b/src/innovate/abm/disruptive_innovation.py
@@ -52,8 +52,8 @@ class DisruptiveInnovationModel(Model):
         # Create agents
         for i in range(self.num_agents):
             agent = DisruptiveInnovationAgent(unique_id=i, model=self)
-            x = self.random.randrange(self.grid.width)
-            y = self.random.randrange(self.grid.height)
+            x = self.random.randrange(self.grid.width)  # nosec
+            y = self.random.randrange(self.grid.height)  # nosec
             self.grid.place_agent(agent, (x, y))
 
         self.datacollector = DataCollector(

--- a/src/innovate/abm/model.py
+++ b/src/innovate/abm/model.py
@@ -1,5 +1,3 @@
-import secrets
-
 from mesa import Model
 from mesa.space import MultiGrid
 
@@ -19,8 +17,8 @@ class InnovationModel(Model):
         for i in range(self.num_agents):
             agent = InnovationAgent(i, self)
             # Add the agent to a random grid cell
-            x = secrets.randbelow(self.grid.width)
-            y = secrets.randbelow(self.grid.height)
+            x = self.random.randrange(self.grid.width)  # nosec
+            y = self.random.randrange(self.grid.height)  # nosec
             self.grid.place_agent(agent, (x, y))
 
     def step(self):

--- a/src/innovate/abm/sentiment_hype_cycle.py
+++ b/src/innovate/abm/sentiment_hype_cycle.py
@@ -61,13 +61,13 @@ class SentimentHypeModel(Model):
         # Create agents
         for i in range(self.num_agents):
             agent = SentimentHypeAgent(unique_id=i, model=self)
-            x = self.random.randrange(self.grid.width)
-            y = self.random.randrange(self.grid.height)
+            x = self.random.randrange(self.grid.width)  # nosec
+            y = self.random.randrange(self.grid.height)  # nosec
             self.grid.place_agent(agent, (x, y))
 
         # Seed initial adopters and sentiment
         for _ in range(5):  # Seed 5 initial adopters
-            agent = self.random.choice(list(self.agents))
+            agent = self.random.choice(list(self.agents))  # nosec
             agent.adopted = True
             agent.sentiment = 1
 


### PR DESCRIPTION
🎯 **What:** The vulnerability flagged was an insecure random number generator (`self.random`) being used in Mesa Agent-Based Models across multiple files.
⚠️ **Risk:** The security scanner reported this as a vulnerability because it was using a non-cryptographic PRNG. However, for Mesa models, cryptographic security is not required; deterministic reproducibility is required. Replacing it with `secrets` (as previously attempted in `model.py`) breaks reproducibility.
🛡️ **Solution:** Reverted the use of `secrets` back to `self.random` and suppressed the false positive security scanner warnings using `# nosec` annotations.

---
*PR created automatically by Jules for task [7170582710133047361](https://jules.google.com/task/7170582710133047361) started by @edithatogo*