### PR TITLE
🧪 [testing improvement] Add missing stability enum tests

### DIFF
--- a/tests/unit/test_stability.py
+++ b/tests/unit/test_stability.py
@@ -92,3 +92,37 @@ def test_stability_aliases_consistency() -> None:
         assert isinstance(alias, str)
         assert isinstance(tier, StabilityTier)
         assert alias.islower()
+
+
+def test_stability_tier_instantiation() -> None:
+    """Test instantiating StabilityTier directly from strings."""
+    assert StabilityTier("stable") is StabilityTier.STABLE
+    assert StabilityTier("provisional") is StabilityTier.PROVISIONAL
+    assert StabilityTier("internal") is StabilityTier.INTERNAL
+
+    with pytest.raises(ValueError, match="is not a valid StabilityTier"):
+        StabilityTier("unknown")
+
+
+def test_stability_lifecycle_rules_completeness() -> None:
+    """Test that all StabilityTier members have lifecycle rules and vice versa."""
+    # Ensure every tier has a lifecycle rule
+    for tier in StabilityTier:
+        assert tier in STABILITY_LIFECYCLE_RULES
+
+    # Ensure there are no extra rules for undefined tiers
+    for tier in STABILITY_LIFECYCLE_RULES:
+        assert isinstance(tier, StabilityTier)
+        assert tier in StabilityTier
+
+
+def test_stability_aliases_exhaustive() -> None:
+    """Test that every StabilityTier can be reached via an alias."""
+    from innovate.stability import _STABILITY_ALIASES
+
+    # Collect all unique tiers targeted by aliases
+    targeted_tiers = set(_STABILITY_ALIASES.values())
+
+    # Ensure all actual enum members are targeted
+    for tier in StabilityTier:
+        assert tier in targeted_tiers


### PR DESCRIPTION
🎯 **What:** Expanded the test suite in `test_stability.py` to cover instantiation of the `StabilityTier` StrEnum directly from strings and verify the completeness/exhaustiveness of `STABILITY_LIFECYCLE_RULES` and `_STABILITY_ALIASES` against the `StabilityTier` enum members.
📊 **Coverage:** Added test cases for string-based instantiation of `StabilityTier`, completeness of lifecycle rules, and exhaustiveness of aliases.
✨ **Result:** Maintained 100% test coverage for `innovate.stability` while adding robust logical assertions to prevent future enum-mapping desyncs.

---
*PR created automatically by Jules for task [10086479455519449148](https://jules.google.com/task/10086479455519449148) started by @edithatogo*