### PR TITLE
🧪 [testing improvement] Add missing error path test in _is_schema_version_compatible

### DIFF
--- a/tests/unit/test_kernel_contract.py
+++ b/tests/unit/test_kernel_contract.py
@@ -367,3 +367,10 @@ def test_list_kernel_operations() -> None:
     operations = kernel.list_kernel_operations()
     assert isinstance(operations, tuple)
     assert "discover_models" in operations
+
+def test_is_schema_version_compatible_handles_value_error() -> None:
+    """_is_schema_version_compatible should return False when ValueError is raised."""
+    from innovate import kernel
+
+    assert kernel._is_schema_version_compatible("invalid") is False
+    assert kernel._is_schema_version_compatible("1.0", "invalid") is False


### PR DESCRIPTION
🎯 **What:** The `_is_schema_version_compatible` function has a ValueError error path that was technically executed when testing missing schemas, but a dedicated test specifically verifying the `ValueError` behavior isolating `invalid` schema versions was missing.
📊 **Coverage:** The ValueError paths triggered by passing malformed schema versions (like `invalid`) are now explicitly covered and validated.
✨ **Result:** Improved test coverage and explicit validation that ValueError instances raised during schema version parsing evaluate correctly to `False` in the version compatibility checker.

---
*PR created automatically by Jules for task [16857616279914063625](https://jules.google.com/task/16857616279914063625) started by @edithatogo*