### PR TITLE
🧪 [Add error path test for get_model_capability]

### DIFF
--- a/tests/unit/test_capabilities.py
+++ b/tests/unit/test_capabilities.py
@@ -60,3 +60,14 @@ def test_get_model_registry():
     registry = get_model_registry()
     assert "bass" in registry
     assert "logistic" in registry
+
+
+def test_get_model_capability_error_path_missing_key():
+    """Test that get_model_capability raises a KeyError and includes __cause__ when key is missing."""
+    with pytest.raises(
+        KeyError, match=r"Unknown model capability 'invalid_key'\. Available models:.*bass.*"
+    ) as exc_info:
+        get_model_capability("invalid_key")
+
+    assert exc_info.value.__cause__ is not None
+    assert isinstance(exc_info.value.__cause__, KeyError)


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
A missing test case for the error path of `get_model_capability` in `src/innovate/capabilities.py`. Although a similar test existed, we've added a more robust one that validates the exact `KeyError` message match (including the formatting of the `key!r` and available models list) as well as the exception's `__cause__` being correctly propagated.

📊 **Coverage:** What scenarios are now tested
The test ensures that `get_model_capability("invalid_key")` raises a `KeyError` with the correct error message format, and explicitly checks that `exc_info.value.__cause__` is an instance of `KeyError`.

✨ **Result:** The improvement in test coverage
The codebase is more reliable by explicitly asserting that the `raise ... from exc` logic in `get_model_capability` is tested.

---
*PR created automatically by Jules for task [6691157309994751782](https://jules.google.com/task/6691157309994751782) started by @edithatogo*