### PR TITLE
🔒 [security fix] Suppress SAST false positives for standard random usage in ABM models

### DIFF
--- a/src/innovate/abm/competitive_diffusion.py
+++ b/src/innovate/abm/competitive_diffusion.py
@@ -58,13 +58,13 @@ class CompetitiveDiffusionModel(Model):
                 model=self,
                 num_innovations=num_innovations,
             )
-            x = self.random.randrange(self.grid.width)
-            y = self.random.randrange(self.grid.height)
+            x = self.random.randrange(self.grid.width)  # nosec B311
+            y = self.random.randrange(self.grid.height)  # nosec B311
             self.grid.place_agent(agent, (x, y))
 
         # Seed initial adopters for each innovation
         for i in range(self.num_innovations):
-            agent = self.random.choice(list(self.agents))
+            agent = self.random.choice(list(self.agents))  # nosec B311
             agent.adopted_innovation = i
 
         # Data collector - track count of adopters for each innovation

--- a/src/innovate/abm/disruptive_innovation.py
+++ b/src/innovate/abm/disruptive_innovation.py
@@ -52,8 +52,8 @@ class DisruptiveInnovationModel(Model):
         # Create agents
         for i in range(self.num_agents):
             agent = DisruptiveInnovationAgent(unique_id=i, model=self)
-            x = self.random.randrange(self.grid.width)
-            y = self.random.randrange(self.grid.height)
+            x = self.random.randrange(self.grid.width)  # nosec B311
+            y = self.random.randrange(self.grid.height)  # nosec B311
             self.grid.place_agent(agent, (x, y))
 
         self.datacollector = DataCollector(

--- a/src/innovate/abm/model.py
+++ b/src/innovate/abm/model.py
@@ -1,5 +1,3 @@
-import secrets
-
 from mesa import Model
 from mesa.space import MultiGrid
 
@@ -19,8 +17,8 @@ class InnovationModel(Model):
         for i in range(self.num_agents):
             agent = InnovationAgent(i, self)
             # Add the agent to a random grid cell
-            x = secrets.randbelow(self.grid.width)
-            y = secrets.randbelow(self.grid.height)
+            x = self.random.randrange(self.grid.width)  # nosec B311
+            y = self.random.randrange(self.grid.height)  # nosec B311
             self.grid.place_agent(agent, (x, y))
 
     def step(self):

--- a/src/innovate/abm/sentiment_hype_cycle.py
+++ b/src/innovate/abm/sentiment_hype_cycle.py
@@ -61,13 +61,13 @@ class SentimentHypeModel(Model):
         # Create agents
         for i in range(self.num_agents):
             agent = SentimentHypeAgent(unique_id=i, model=self)
-            x = self.random.randrange(self.grid.width)
-            y = self.random.randrange(self.grid.height)
+            x = self.random.randrange(self.grid.width)  # nosec B311
+            y = self.random.randrange(self.grid.height)  # nosec B311
             self.grid.place_agent(agent, (x, y))
 
         # Seed initial adopters and sentiment
         for _ in range(5):  # Seed 5 initial adopters
-            agent = self.random.choice(list(self.agents))
+            agent = self.random.choice(list(self.agents))  # nosec B311
             agent.adopted = True
             agent.sentiment = 1
 


### PR DESCRIPTION
🎯 **What:** The vulnerability reported was `B311` (insecure random number generator) regarding the use of standard pseudo-random number generators in the ABM models.

⚠️ **Risk:** While using non-cryptographic PRNGs can be a security risk in many contexts, in the case of Agent-Based Modeling (ABM) and scientific simulations with Mesa, reproducible randomness (via seeds) is a hard requirement. Replacing `self.random` with a cryptographic alternative like `secrets` would break the deterministic nature of the simulations, which is a major functional regression.

🛡️ **Solution:** Rather than breaking reproducibility, the correct solution is to suppress the SAST scanner's false-positive warnings. This commit reverts any changes to `secrets` and appends `# nosec B311` to usages of `self.random` across the `innovate/abm` models.

---
*PR created automatically by Jules for task [8812066865292331920](https://jules.google.com/task/8812066865292331920) started by @edithatogo*