### PR TITLE
🔒 [security fix] Remove hardcoded authorization context in InProcessRemoteExecutor

### DIFF
--- a/src/innovate/remote_execution.py
+++ b/src/innovate/remote_execution.py
@@ -166,7 +166,9 @@ class InProcessRemoteExecutor:
         runtime: str = "python",
         backend: str = "numpy_scipy",
     ) -> None:
-        self.policy = policy or RemoteExecutionPolicy(required_auth_scope="kernel:execute")
+        if policy is None:
+            raise ValueError("RemoteExecutionPolicy must be explicitly provided for secure authorization.")
+        self.policy = policy
         self.runtime = runtime
         self.backend = backend
 
@@ -234,7 +236,7 @@ class InProcessRemoteExecutor:
 
 def describe_remote_execution_contract() -> dict[str, Any]:
     """Describe remote execution boundaries, security, and observability requirements."""
-    policy = RemoteExecutionPolicy(required_auth_scope="kernel:execute")
+    policy = RemoteExecutionPolicy(required_auth_scope="<REQUIRED_SCOPE>")
     return {
         "schema_version": kernel.KERNEL_SCHEMA_VERSION,
         "eligible_operations": policy.eligible_operations,

--- a/tests/unit/test_remote_execution.py
+++ b/tests/unit/test_remote_execution.py
@@ -26,7 +26,7 @@ def test_remote_execution_contract_documents_boundaries_and_risk_controls() -> N
 
 def test_in_process_remote_executor_preserves_kernel_schema_and_correlation() -> None:
     """The local adapter should wrap kernel responses without changing the kernel ABI."""
-    executor = InProcessRemoteExecutor()
+    executor = InProcessRemoteExecutor(policy=RemoteExecutionPolicy(required_auth_scope="kernel:execute"))
     request = RemoteExecutionRequest(
         kernel_request=kernel.KernelRequest(
             operation=kernel.KernelOperation.DISCOVER_MODELS.value,


### PR DESCRIPTION
🎯 **What:** The `RemoteExecutionPolicy` and its fallback instantiations previously hardcoded the `"kernel:execute"` authorization context, which could allow arbitrary clients to assume authorization scope defaults inadvertently.
⚠️ **Risk:** Hardcoding authorization contexts means environments running multiple adapters or tenants might inadvertently grant permission when standard defaults are instantiated incorrectly.
🛡️ **Solution:** Removed the hardcoded defaults. `InProcessRemoteExecutor` now explicitly requires the policy to be provided, and `describe_remote_execution_contract` uses a placeholder.

---
*PR created automatically by Jules for task [13851351611256101443](https://jules.google.com/task/13851351611256101443) started by @edithatogo*