### PR TITLE
chore: pin latest Conductor upstream

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,5 @@
+[submodule ".agents/plugins/conductor"]
+	path = .agents/plugins/conductor
+	url = https://github.com/gemini-cli-extensions/conductor.git
+	branch = main
+


### PR DESCRIPTION
Pin the latest upstream Conductor main commit as an immutable Git submodule.`n`n- upstream: $upstream`n- commit: $pin`n- initialize: `git submodule update --init --recursive``n`nValidation: exact mode-160000 gitlink, canonical URL, and a tree constructed directly from the current default branch. This repository was included because its default branch already contains root Conductor context.